### PR TITLE
Replace beta_fr_ema with kappa for eligibility trace filtering

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -386,13 +386,12 @@ eprop_iaf::compute_gradient( const long t_spike,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
-  long t = t_previous_spike;    // inter-spike time step
-  double e = 0.0;               // eligibility trace
-  double z = 0.0;               // spiking variable
-  double psi = 0.0;             // surrogate gradient
-  double L = 0.0;               // learning signal
-  double firing_rate_reg = 0.0; // firing rate regularization
-  double grad = 0.0;            // gradient
+  long t = t_previous_spike; // inter-spike time step
+  double e = 0.0;            // eligibility trace
+  double z = 0.0;            // spiking variable
+  double psi = 0.0;          // surrogate gradient
+  double L = 0.0;            // learning signal
+  double grad = 0.0;         // gradient
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
@@ -423,12 +422,11 @@ eprop_iaf::compute_gradient( const long t_spike,
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;
-    firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
     z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = ( L + firing_rate_reg ) * e_bar;
+    grad = L * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -190,7 +190,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -81,7 +81,7 @@ eprop_iaf::Parameters_::Parameters_()
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
   , V_th_( -55.0 - E_L_ )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )    
+  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
 {
 }
@@ -127,7 +127,7 @@ eprop_iaf::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::tau_m, tau_m_ );
   def< double >( d, names::V_min, V_min_ + E_L_ );
   def< double >( d, names::V_th, V_th_ + E_L_ );
-  def< double >( d, names::kappa, kappa_ );    
+  def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
 }
 
@@ -157,7 +157,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
   updateValueParam< double >( d, names::t_ref, t_ref_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
-  updateValueParam< double >( d, names::kappa, kappa_, node );    
+  updateValueParam< double >( d, names::kappa, kappa_, node );
   updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
 
   if ( C_m_ <= 0 )
@@ -428,7 +428,7 @@ eprop_iaf::compute_gradient( const long t_spike,
     z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = (L + firing_rate_reg)  * e_bar;
+    grad = ( L + firing_rate_reg ) * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -190,9 +190,9 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1] required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -192,7 +192,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
 
   if ( kappa_ <= 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "kappa must be in the range (0, 1)" );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -190,7 +190,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ <= 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -286,7 +286,6 @@ public:
     double& epsilon,
     double& avg_e,
     double& weight,
-    const double kappa,
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
@@ -354,8 +353,8 @@ private:
     //! Spike threshold voltage relative to the leak membrane potential (mV).
     double V_th_;
 
-    //! Smoothing factor of firing rate exponential moving average.
-    double beta_fr_ema_;
+    //! Low-pass filter of the eligibility trace.
+    double kappa_;    
 
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -354,7 +354,7 @@ private:
     double V_th_;
 
     //! Low-pass filter of the eligibility trace.
-    double kappa_;    
+    double kappa_;
 
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -210,7 +210,7 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -424,13 +424,12 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
-  long t = t_previous_spike;    // inter-spike time step
-  double e = 0.0;               // eligibility trace
-  double z = 0.0;               // spiking variable
-  double psi = 0.0;             // surrogate gradient
-  double L = 0.0;               // learning signal
-  double firing_rate_reg = 0.0; // firing rate regularization
-  double grad = 0.0;            // gradient
+  long t = t_previous_spike; // inter-spike time step
+  double e = 0.0;            // eligibility trace
+  double z = 0.0;            // spiking variable
+  double psi = 0.0;          // surrogate gradient
+  double L = 0.0;            // learning signal
+  double grad = 0.0;         // gradient
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
@@ -461,13 +460,12 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;
-    firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
     z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = psi * z_bar + ( V_.P_adapt_ - psi * P_.adapt_beta_ ) * epsilon;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = ( L + firing_rate_reg ) * e_bar;
+    grad = L * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -85,7 +85,7 @@ eprop_iaf_adapt::Parameters_::Parameters_()
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
   , V_th_( -55.0 - E_L_ )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )    
+  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
 {
 }
@@ -128,14 +128,14 @@ eprop_iaf_adapt::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::f_target, f_target_ );
   def< double >( d, names::beta, beta_ );
   def< double >( d, names::gamma, gamma_ );
-  def< double >( d, names::I_e, I_e_ );  
+  def< double >( d, names::I_e, I_e_ );
   def< bool >( d, names::regular_spike_arrival, regular_spike_arrival_ );
   def< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_ );
   def< double >( d, names::t_ref, t_ref_ );
   def< double >( d, names::tau_m, tau_m_ );
   def< double >( d, names::V_min, V_min_ + E_L_ );
   def< double >( d, names::V_th, V_th_ + E_L_ );
-  def< double >( d, names::kappa, kappa_ );    
+  def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
 }
 
@@ -167,7 +167,7 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
   updateValueParam< double >( d, names::t_ref, t_ref_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
-  updateValueParam< double >( d, names::kappa, kappa_, node );    
+  updateValueParam< double >( d, names::kappa, kappa_, node );
   updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
 
   if ( adapt_beta_ < 0 )
@@ -467,7 +467,7 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = psi * z_bar + ( V_.P_adapt_ - psi * P_.adapt_beta_ ) * epsilon;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = (L + firing_rate_reg) * e_bar;
+    grad = ( L + firing_rate_reg ) * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -210,9 +210,9 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1] required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -212,7 +212,7 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
 
   if ( kappa_ <= 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "kappa must be in the range (0, 1)" );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -210,7 +210,7 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Spike threshold voltage V_th ≥ minimal voltage V_min required." );
   }
 
-  if ( kappa_ <= 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -377,7 +377,7 @@ private:
     double V_th_;
 
     //! Low-pass filter of the eligibility trace.
-    double kappa_;    
+    double kappa_;
 
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -303,7 +303,6 @@ public:
     double& epsilon,
     double& avg_e,
     double& weight,
-    const double kappa,
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
@@ -377,8 +376,8 @@ private:
     //! Spike threshold voltage relative to the leak membrane potential (mV).
     double V_th_;
 
-    //! Smoothing factor of firing rate exponential moving average.
-    double beta_fr_ema_;
+    //! Low-pass filter of the eligibility trace.
+    double kappa_;    
 
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -207,9 +207,9 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
     throw BadProperty( "Firing rate regularization target rate f_target ≥ 0 required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1] required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -207,7 +207,7 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
     throw BadProperty( "Firing rate regularization target rate f_target ≥ 0 required." );
   }
 
-  if ( kappa_ < 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ >= 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -469,13 +469,12 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
-  long t = t_previous_spike;    // inter-spike time step
-  double e = 0.0;               // eligibility trace
-  double z = 0.0;               // spiking variable
-  double psi = 0.0;             // surrogate gradient
-  double L = 0.0;               // learning signal
-  double firing_rate_reg = 0.0; // firing rate regularization
-  double grad = 0.0;            // gradient
+  long t = t_previous_spike; // inter-spike time step
+  double e = 0.0;            // eligibility trace
+  double z = 0.0;            // spiking variable
+  double psi = 0.0;          // surrogate gradient
+  double L = 0.0;            // learning signal
+  double grad = 0.0;         // gradient
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
@@ -506,12 +505,11 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;
-    firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
     z_bar = V_.P33_ * z_bar + V_.P_z_in_ * z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = ( L + firing_rate_reg ) * e_bar;
+    grad = L * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -207,7 +207,7 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
     throw BadProperty( "Firing rate regularization target rate f_target ≥ 0 required." );
   }
 
-  if ( kappa_ <= 0.0 or kappa_ > 1.0 )
+  if ( kappa_ < 0.0 or kappa_ > 1.0 )
   {
     throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -209,7 +209,7 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
 
   if ( kappa_ <= 0.0 or kappa_ > 1.0 )
   {
-    throw BadProperty( "kappa must be in the range (0, 1)" );
+    throw BadProperty( "Eligibility trace low-pass filter from range [0, 1) required." );
   }
 
   if ( eprop_isi_trace_cutoff_ < 0 )

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -76,7 +76,7 @@ nest::eprop_iaf_psc_delta::Parameters_::Parameters_()
   , c_m_( 250.0 )                                   // pF
   , t_ref_( 2.0 )                                   // ms
   , E_L_( -70.0 )                                   // mV
-  , I_e_( 0.0 )                                     // pA  
+  , I_e_( 0.0 )                                     // pA
   , V_th_( -55.0 - E_L_ )                           // mV, rel to E_L_
   , V_min_( -std::numeric_limits< double >::max() ) // relative E_L_-55.0-E_L_
   , V_reset_( -70.0 - E_L_ )                        // mV, rel to E_L_
@@ -87,7 +87,7 @@ nest::eprop_iaf_psc_delta::Parameters_::Parameters_()
   , gamma_( 0.3 )
   , surrogate_gradient_function_( "piecewise_linear" )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )    
+  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
 {
 }
 
@@ -123,7 +123,7 @@ nest::eprop_iaf_psc_delta::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::beta, beta_ );
   def< double >( d, names::gamma, gamma_ );
   def< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_ );
-  def< double >( d, names::kappa, kappa_ );      
+  def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
 }
 
@@ -176,8 +176,8 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
   updateValueParam< double >( d, names::beta, beta_, node );
   updateValueParam< double >( d, names::gamma, gamma_, node );
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
-  updateValueParam< double >( d, names::kappa, kappa_, node );   
-  updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );   
+  updateValueParam< double >( d, names::kappa, kappa_, node );
+  updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
 
   if ( V_reset_ >= V_th_ )
   {
@@ -511,7 +511,7 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
     z_bar = V_.P33_ * z_bar + V_.P_z_in_ * z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
-    grad = (L + firing_rate_reg) * e_bar;
+    grad = ( L + firing_rate_reg ) * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
 

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -266,7 +266,7 @@ private:
     std::string surrogate_gradient_function_;
 
     //! Low-pass filter of the eligibility trace.
-    double kappa_;    
+    double kappa_;
 
     //!< Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //!< eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -188,7 +188,6 @@ public:
     double& epsilon,
     double& avg_e,
     double& weight,
-    const double kappa,
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
@@ -266,8 +265,8 @@ private:
     //! "fast_sigmoid_derivative", "arctan"]
     std::string surrogate_gradient_function_;
 
-    //! Smoothing factor of firing rate exponential moving average.
-    double beta_fr_ema_;
+    //! Low-pass filter of the eligibility trace.
+    double kappa_;    
 
     //!< Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //!< eprop_isi_trace_cutoff_ and the inter-spike distance.

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -343,7 +343,6 @@ eprop_readout::compute_gradient( const long t_spike,
   double& epsilon,
   double& avg_e,
   double& weight,
-  const double kappa,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -239,7 +239,6 @@ public:
     double& epsilon,
     double& avg_e,
     double& weight,
-    const double kappa,
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 

--- a/models/eprop_synapse.h
+++ b/models/eprop_synapse.h
@@ -312,9 +312,6 @@ private:
   //! %Time constant for low-pass filtering the eligibility trace.
   double tau_m_readout_;
 
-  //! Low-pass filter of the eligibility trace.
-  double kappa_;
-
   /**
    *  Optimizer
    *
@@ -355,7 +352,6 @@ eprop_synapse< targetidentifierT >::eprop_synapse()
   , weight_( 1.0 )
   , t_previous_spike_( 0 )
   , t_previous_trigger_spike_( 0 )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
   , optimizer_( nullptr )
 {
 }
@@ -373,7 +369,6 @@ eprop_synapse< targetidentifierT >::eprop_synapse( const eprop_synapse& es )
   , weight_( es.weight_ )
   , t_previous_spike_( 0 )
   , t_previous_trigger_spike_( 0 )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
   , optimizer_( es.optimizer_ )
 {
 }
@@ -393,7 +388,6 @@ eprop_synapse< targetidentifierT >::operator=( const eprop_synapse& es )
   weight_ = es.weight_;
   t_previous_spike_ = es.t_previous_spike_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
-  kappa_ = es.kappa_;
   optimizer_ = es.optimizer_;
 
   return *this;
@@ -405,7 +399,6 @@ eprop_synapse< targetidentifierT >::eprop_synapse( eprop_synapse&& es )
   , weight_( es.weight_ )
   , t_previous_spike_( 0 )
   , t_previous_trigger_spike_( 0 )
-  , kappa_( es.kappa_ )
   , optimizer_( es.optimizer_ )
 {
   es.optimizer_ = nullptr;
@@ -426,7 +419,6 @@ eprop_synapse< targetidentifierT >::operator=( eprop_synapse&& es )
   weight_ = es.weight_;
   t_previous_spike_ = es.t_previous_spike_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
-  kappa_ = es.kappa_;
 
   optimizer_ = es.optimizer_;
   es.optimizer_ = nullptr;
@@ -488,7 +480,6 @@ eprop_synapse< targetidentifierT >::send( Event& e, size_t thread, const EpropSy
       epsilon_,
       avg_e_,
       weight_,
-      kappa_,
       cp,
       optimizer_ );
     t_begin = t_previous_spike_;
@@ -514,7 +505,6 @@ eprop_synapse< targetidentifierT >::get_status( DictionaryDatum& d ) const
 {
   ConnectionBase::get_status( d );
   def< double >( d, names::weight, weight_ );
-  def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::size_of, sizeof( *this ) );
 
   DictionaryDatum optimizer_dict = new Dictionary();
@@ -543,14 +533,6 @@ eprop_synapse< targetidentifierT >::set_status( const DictionaryDatum& d, Connec
   }
 
   updateValue< double >( d, names::weight, weight_ );
-
-  if ( updateValue< double >( d, names::kappa, kappa_ ) )
-  {
-    if ( kappa_ <= 0.0 or kappa_ > 1.0 )
-    {
-      throw BadProperty( "kappa must be in the range (0, 1)" );
-    }
-  }
 
   const auto& gcm = dynamic_cast< const GenericConnectorModel< eprop_synapse< targetidentifierT > >& >( cm );
   const CommonPropertiesType& epcp = gcm.get_common_properties();

--- a/models/eprop_synapse.h
+++ b/models/eprop_synapse.h
@@ -472,16 +472,8 @@ eprop_synapse< targetidentifierT >::send( Event& e, size_t thread, const EpropSy
   }
   else
   {
-    target->compute_gradient( t_spike,
-      t_previous_spike_,
-      previous_z_buffer_,
-      z_bar_,
-      e_bar_,
-      epsilon_,
-      avg_e_,
-      weight_,
-      cp,
-      optimizer_ );
+    target->compute_gradient(
+      t_spike, t_previous_spike_, previous_z_buffer_, z_bar_, e_bar_, epsilon_, avg_e_, weight_, cp, optimizer_ );
     t_begin = t_previous_spike_;
   }
 

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -126,7 +126,7 @@ EpropArchivingNodeRecurrent::write_surrogate_gradient_to_history( const long tim
     return;
   }
 
-  eprop_history_.emplace_back( time_step, surrogate_gradient, 0.0, 0.0 );
+  eprop_history_.emplace_back( time_step, surrogate_gradient, 0.0 );
 }
 
 void
@@ -208,7 +208,7 @@ EpropArchivingNodeRecurrent::write_firing_rate_reg_to_history( const long t,
   firing_rate_reg_ = c_reg * ( f_av_ - f_target_ );
 
   auto it_hist = get_eprop_history( t );
-  it_hist->firing_rate_reg_ = firing_rate_reg_;
+  it_hist->learning_signal_ += firing_rate_reg_;
 }
 
 double

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -191,7 +191,7 @@ EpropArchivingNodeRecurrent::write_firing_rate_reg_to_history( const long t,
   const long interval_step,
   const double z,
   const double f_target,
-  const double beta_fr_ema,
+  const double kappa,
   const double c_reg )
 {
   if ( eprop_indegree_ == 0 )
@@ -203,7 +203,7 @@ EpropArchivingNodeRecurrent::write_firing_rate_reg_to_history( const long t,
 
   const double f_target_ = f_target * dt; // convert from spikes/ms to spikes/step
 
-  f_av_ = beta_fr_ema * f_av_ + ( 1.0 - beta_fr_ema ) * z / dt;
+  f_av_ = kappa * f_av_ + ( 1.0 - kappa ) * z / dt;
 
   firing_rate_reg_ = c_reg * ( f_av_ - f_target_ );
 

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -199,7 +199,7 @@ public:
     const long interval_step,
     const double z,
     const double f_target,
-    const double beta_fr_ema,
+    const double kappa,
     const double c_reg );
 
   //! Get an iterator pointing to the firing rate regularization history of the given time step.

--- a/nestkernel/histentry.cpp
+++ b/nestkernel/histentry.cpp
@@ -42,14 +42,10 @@ nest::HistEntryEprop::HistEntryEprop( long t )
 {
 }
 
-nest::HistEntryEpropRecurrent::HistEntryEpropRecurrent( long t,
-  double surrogate_gradient,
-  double learning_signal,
-  double firing_rate_reg )
+nest::HistEntryEpropRecurrent::HistEntryEpropRecurrent( long t, double surrogate_gradient, double learning_signal )
   : HistEntryEprop( t )
   , surrogate_gradient_( surrogate_gradient )
   , learning_signal_( learning_signal )
-  , firing_rate_reg_( firing_rate_reg )
 {
 }
 

--- a/nestkernel/histentry.h
+++ b/nestkernel/histentry.h
@@ -92,11 +92,10 @@ operator<( const HistEntryEprop& he, long t )
 class HistEntryEpropRecurrent : public HistEntryEprop
 {
 public:
-  HistEntryEpropRecurrent( long t, double surrogate_gradient, double learning_signal, double firing_rate_reg );
+  HistEntryEpropRecurrent( long t, double surrogate_gradient, double learning_signal );
 
   double surrogate_gradient_;
   double learning_signal_;
-  double firing_rate_reg_;
 };
 
 /**

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -83,7 +83,6 @@ const Name beta( "beta" );
 const Name beta_1( "beta_1" );
 const Name beta_2( "beta_2" );
 const Name beta_Ca( "beta_Ca" );
-const Name beta_fr_ema( "beta_fr_ema" );
 const Name biological_time( "biological_time" );
 const Name box( "box" );
 const Name buffer_size( "buffer_size" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -110,7 +110,6 @@ extern const Name beta_1;
 extern const Name beta_2;
 
 extern const Name beta_Ca;
-extern const Name beta_fr_ema;
 extern const Name biological_time;
 extern const Name box;
 extern const Name buffer_size;

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -559,7 +559,6 @@ nest::Node::compute_gradient( const long t_spike,
   double& epsilon,
   double& avg_e,
   double& weight,
-  const double kappa,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -829,7 +829,6 @@ public:
     double& epsilon,
     double& avg_e,
     double& weight,
-    const double kappa,
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer );
 

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_mnist.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_mnist.py
@@ -185,9 +185,19 @@ n_out = 10
 
 model_nrn_rec = "eprop_iaf_psc_delta"
 
+params_nrn_out = {
+    "C_m": 1.0,
+    "E_L": 0.0,
+    "eprop_isi_trace_cutoff": 100,  # cutoff of integration of eprop trace between spikes
+    "I_e": 0.0,
+    "loss": "mean_squared_error",  # loss function
+    "regular_spike_arrival": False,
+    "tau_m": 20.0,
+    "V_m": 0.0,
+}
+
 params_nrn_rec = {
     "beta": 1.0,  # width scaling of the pseudo-derivative
-    "beta_fr_ema": 0.999,  # Smoothing factor of firing rate exponential moving average
     "C_m": 1.0,  # pF, membrane capacitance - takes effect only if neurons get current input (here not the case)
     "c_reg": 2.0 / duration["sequence"],  # firing rate regularization scaling
     "E_L": 0.0,  # mV, leak reversal potential
@@ -201,6 +211,9 @@ params_nrn_rec = {
     "V_m": 0.0,  # mV, initial value of the membrane voltage
     "V_th": 0.5,  # mV, spike threshold membrane voltage
     "V_reset": -0.5,
+    "kappa": np.exp(
+        -duration["step"] / params_nrn_out["tau_m"]
+    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
 }
 
 if model_nrn_rec == "eprop_iaf":
@@ -208,18 +221,6 @@ if model_nrn_rec == "eprop_iaf":
     params_nrn_rec["c_reg"] = 300.0 / duration["sequence"]  # firing rate regularization scaling
     params_nrn_rec["regular_spike_arrival"] = True  # postsynaptic current scale factor
     params_nrn_rec["V_th"] = 0.6  # mV, spike threshold membrane voltage
-
-
-params_nrn_out = {
-    "C_m": 1.0,
-    "E_L": 0.0,
-    "eprop_isi_trace_cutoff": 100,  # cutoff of integration of eprop trace between spikes
-    "I_e": 0.0,
-    "loss": "mean_squared_error",  # loss function
-    "regular_spike_arrival": False,
-    "tau_m": 20.0,
-    "V_m": 0.0,
-}
 
 ####################
 
@@ -317,9 +318,6 @@ params_common_syn_eprop = {
 params_syn_base = {
     "synapse_model": "eprop_synapse",
     "delay": duration["step"],  # ms, dendritic delay
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
 }
 
 params_syn_in = params_syn_base.copy()

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
@@ -184,9 +184,19 @@ n_out = 10
 
 model_nrn_rec = "eprop_iaf"
 
+params_nrn_out = {
+    "C_m": 1.0,
+    "E_L": 0.0,
+    "eprop_isi_trace_cutoff": 10**2,  # cutoff of integration of eprop trace between spikes
+    "I_e": 0.0,
+    "loss": "mean_squared_error",  # loss function
+    "regular_spike_arrival": False,
+    "tau_m": 100.0,
+    "V_m": 0.0,
+}
+
 params_nrn_rec = {
     "beta": 1.0,  # widht scaling of the pseudo-derivative
-    "beta_fr_ema": 0.999,  # Smoothing factor of firing rate exponential moving average
     "C_m": 1.0,  # pF, membrane capacitance - takes effect only if neurons get current input (here not the case)
     "c_reg": 2.0 / duration["sequence"],  # firing rate regularization scaling
     "E_L": 0.0,  # mV, leak reversal potential
@@ -200,6 +210,10 @@ params_nrn_rec = {
     "V_m": 0.0,  # mV, initial value of the membrane voltage
     "V_th": 0.5,  # mV, spike threshold membrane voltage
     "V_reset": -0.5,
+    "kappa": np.exp(
+        -duration["step"] / params_nrn_out["tau_m"]
+    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
+
 }
 
 if model_nrn_rec == "eprop_iaf":
@@ -207,17 +221,6 @@ if model_nrn_rec == "eprop_iaf":
     params_nrn_rec["c_reg"] = 2.0 / duration["sequence"]  # firing rate regularization scaling
     params_nrn_rec["regular_spike_arrival"] = True  # postsynaptic current scale factor
     params_nrn_rec["V_th"] = 0.6  # mV, spike threshold membrane voltage
-
-params_nrn_out = {
-    "C_m": 1.0,
-    "E_L": 0.0,
-    "eprop_isi_trace_cutoff": 10**2,  # cutoff of integration of eprop trace between spikes
-    "I_e": 0.0,
-    "loss": "mean_squared_error",  # loss function
-    "regular_spike_arrival": False,
-    "tau_m": 100.0,
-    "V_m": 0.0,
-}
 
 ####################
 
@@ -324,9 +327,6 @@ params_common_syn_eprop = {
 params_syn_base = {
     "synapse_model": "eprop_synapse",
     "delay": duration["step"],  # ms, dendritic delay
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
 }
 
 params_syn_in = params_syn_base.copy()

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
@@ -170,9 +170,19 @@ n_out = 1  # number of readout neurons
 
 model_nrn_rec = "eprop_iaf_psc_delta"
 
+params_nrn_out = {
+    "C_m": 1.0,
+    "E_L": 0.0,
+    "eprop_isi_trace_cutoff": 10,
+    "I_e": 0.0,
+    "loss": "mean_squared_error",  # loss function
+    "regular_spike_arrival": False,
+    "tau_m": 30.0,
+    "V_m": 0.0,
+}
+
 params_nrn_rec = {
     "beta": 1.0,  # width scaling of the pseudo-derivative
-    "beta_fr_ema": 0.999,  # Smoothing factor of firing rate exponential moving average
     "C_m": 1.0,  # pF, membrane capacitance - takes effect only if neurons get current input (here not the case)
     "c_reg": 2.0 / duration["sequence"],  # firing rate regularization scaling
     "E_L": 0.0,  # mV, leak / resting membrane potential
@@ -186,6 +196,10 @@ params_nrn_rec = {
     "V_m": 0.0,  # mV, initial value of the membrane voltage
     "V_th": 0.5,  # mV, spike threshold membrane voltage
     "V_reset": -0.5,
+    "kappa": np.exp(
+        -duration["step"] / params_nrn_out["tau_m"]
+    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
+
 }
 
 if model_nrn_rec == "eprop_iaf":
@@ -193,18 +207,6 @@ if model_nrn_rec == "eprop_iaf":
     params_nrn_rec["c_reg"] = 300.0 / duration["sequence"]  # firing rate regularization scaling
     params_nrn_rec["regular_spike_arrival"] = False  # postsynaptic current scale factor
     params_nrn_rec["V_th"] = 0.03  # mV, spike threshold membrane voltage
-
-
-params_nrn_out = {
-    "C_m": 1.0,
-    "E_L": 0.0,
-    "eprop_isi_trace_cutoff": 10,
-    "I_e": 0.0,
-    "loss": "mean_squared_error",  # loss function
-    "regular_spike_arrival": False,
-    "tau_m": 30.0,
-    "V_m": 0.0,
-}
 
 ####################
 
@@ -293,9 +295,6 @@ params_common_syn_eprop = {
 params_syn_base = {
     "synapse_model": "eprop_synapse",
     "delay": duration["step"],  # ms, dendritic delay
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
 }
 
 params_syn_in = params_syn_base.copy()


### PR DESCRIPTION
Previously, models utilized a parameter named `beta_fr_ema` to control the low-pass filtering of the firing rate regularization term. This update replaces `beta_fr_ema` with `kappa` which standardize the treatment of both the learning signal and firing rate regularization contributions, thereby simplifying notation and saving computations.
