### PR TITLE
Remove zero compensating delays from online tutorials

### DIFF
--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_mnist.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_mnist.py
@@ -135,13 +135,11 @@ steps.update(
     {
         "offset_gen": 1,  # offset since generator signals start from time step 1
         "delay_in_rec": 1,  # connection delay between input and recurrent neurons
-        "delay_rec_out": 0,  # connection delay between recurrent and output neurons
-        "delay_out_norm": 0,  # connection delay between output neurons for normalization
-        "extension_sim": 1 + 2,  # extra time step to close right-open simulation time interval in Simulate()
+        "extension_sim": 3,  # extra time step to close right-open simulation time interval in Simulate()
     }
 )
 
-steps["delays"] = steps["delay_in_rec"] + steps["delay_rec_out"] + steps["delay_out_norm"]  # time steps of delays
+steps["delays"] = steps["delay_in_rec"]  # time steps of delays
 
 steps["total_offset"] = steps["offset_gen"] + steps["delays"]  # time steps of total offset
 

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
@@ -132,13 +132,11 @@ steps.update(
     {
         "offset_gen": 1,  # offset since generator signals start from time step 1
         "delay_in_rec": 1,  # connection delay between input and recurrent neurons
-        "delay_rec_out": 0,  # connection delay between recurrent and output neurons
-        "delay_out_norm": 0,  # connection delay between output neurons for normalization
-        "extension_sim": 1 + 2,  # extra time step to close right-open simulation time interval in Simulate()
+        "extension_sim": 3,  # extra time step to close right-open simulation time interval in Simulate()
     }
 )
 
-steps["delays"] = steps["delay_in_rec"] + steps["delay_rec_out"] + steps["delay_out_norm"]  # time steps of delays
+steps["delays"] = steps["delay_in_rec"]  # time steps of delays
 
 steps["total_offset"] = steps["offset_gen"] + steps["delays"]  # time steps of total offset
 
@@ -213,7 +211,6 @@ params_nrn_rec = {
     "kappa": np.exp(
         -duration["step"] / params_nrn_out["tau_m"]
     ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
-
 }
 
 if model_nrn_rec == "eprop_iaf":

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
@@ -122,13 +122,11 @@ steps.update(
     {
         "offset_gen": 1,  # offset since generator signals start from time step 1
         "delay_in_rec": 1,  # connection delay between input and recurrent neurons
-        "delay_rec_out": 0,  # connection delay between recurrent and output neurons
-        "delay_out_norm": 0,  # connection delay between output neurons for normalization
         "extension_sim": 3,  # extra time step to close right-open simulation time interval in Simulate()
     }
 )
 
-steps["delays"] = steps["delay_in_rec"] + steps["delay_rec_out"] + steps["delay_out_norm"]  # time steps of delays
+steps["delays"] = steps["delay_in_rec"]  # time steps of delays
 
 steps["total_offset"] = steps["offset_gen"] + steps["delays"]  # time steps of total offset
 
@@ -199,7 +197,6 @@ params_nrn_rec = {
     "kappa": np.exp(
         -duration["step"] / params_nrn_out["tau_m"]
     ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
-
 }
 
 if model_nrn_rec == "eprop_iaf":


### PR DESCRIPTION
This PR removes all the delays equal to zero in the online eprop tutorials.