### PR TITLE
Separate creating and writing eprop history

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -302,6 +302,8 @@ eprop_iaf::update( Time const& origin, const long from, const long to )
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
+    create_eprop_history_entry( t );
+
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 
     if ( S_.v_m_ >= P_.V_th_ and S_.r_ == 0 )

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -302,7 +302,7 @@ eprop_iaf::update( Time const& origin, const long from, const long to )
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -340,6 +340,8 @@ eprop_iaf_adapt::update( Time const& origin, const long from, const long to )
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, S_.v_th_adapt_, P_.V_th_, P_.beta_, P_.gamma_ );
 
+    create_eprop_history_entry( t );
+
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 
     if ( S_.v_m_ >= S_.v_th_adapt_ and S_.r_ == 0 )

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -340,7 +340,7 @@ eprop_iaf_adapt::update( Time const& origin, const long from, const long to )
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, S_.v_th_adapt_, P_.V_th_, P_.beta_, P_.gamma_ );
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 

--- a/models/eprop_iaf_adapt_bsshslm_2020.cpp
+++ b/models/eprop_iaf_adapt_bsshslm_2020.cpp
@@ -344,6 +344,8 @@ eprop_iaf_adapt_bsshslm_2020::update( Time const& origin, const long from, const
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, S_.v_th_adapt_, P_.V_th_, P_.beta_, P_.gamma_ );
 
+    create_eprop_history_entry( t );
+
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 
     if ( S_.v_m_ >= S_.v_th_adapt_ and S_.r_ == 0 )

--- a/models/eprop_iaf_adapt_bsshslm_2020.cpp
+++ b/models/eprop_iaf_adapt_bsshslm_2020.cpp
@@ -344,7 +344,7 @@ eprop_iaf_adapt_bsshslm_2020::update( Time const& origin, const long from, const
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, S_.v_th_adapt_, P_.V_th_, P_.beta_, P_.gamma_ );
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 

--- a/models/eprop_iaf_bsshslm_2020.cpp
+++ b/models/eprop_iaf_bsshslm_2020.cpp
@@ -305,6 +305,8 @@ eprop_iaf_bsshslm_2020::update( Time const& origin, const long from, const long 
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
+    create_eprop_history_entry( t );
+
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 
     if ( S_.v_m_ >= P_.V_th_ and S_.r_ == 0 )

--- a/models/eprop_iaf_bsshslm_2020.cpp
+++ b/models/eprop_iaf_bsshslm_2020.cpp
@@ -305,7 +305,7 @@ eprop_iaf_bsshslm_2020::update( Time const& origin, const long from, const long 
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.v_m_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -381,6 +381,8 @@ nest::eprop_iaf_psc_delta::update( Time const& origin, const long from, const lo
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.y3_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
+    create_eprop_history_entry( t );
+
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 
 

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -381,7 +381,7 @@ nest::eprop_iaf_psc_delta::update( Time const& origin, const long from, const lo
     S_.surrogate_gradient_ =
       ( this->*compute_surrogate_gradient )( S_.r_, S_.y3_, P_.V_th_, P_.V_th_, P_.beta_, P_.gamma_ );
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_surrogate_gradient_to_history( t, S_.surrogate_gradient_ );
 

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -251,7 +251,7 @@ eprop_readout::update( Time const& origin, const long from, const long to )
 
     error_signal_buffer[ lag ] = S_.error_signal_;
 
-    create_eprop_history_entry( t, false );
+    emplace_new_eprop_history_entry( t, false );
 
     write_error_signal_to_history( t, S_.error_signal_, false );
 

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -251,6 +251,8 @@ eprop_readout::update( Time const& origin, const long from, const long to )
 
     error_signal_buffer[ lag ] = S_.error_signal_;
 
+    create_eprop_history_entry( t, false );
+
     write_error_signal_to_history( t, S_.error_signal_, false );
 
     S_.i_in_ = B_.currents_.get_value( lag ) + P_.I_e_;

--- a/models/eprop_readout_bsshslm_2020.cpp
+++ b/models/eprop_readout_bsshslm_2020.cpp
@@ -259,7 +259,6 @@ eprop_readout_bsshslm_2020::update( Time const& origin, const long from, const l
     const long interval_step = ( t - shift ) % update_interval;
     const long interval_step_signals = ( t - shift - delay_out_norm_ ) % update_interval;
 
-
     if ( interval_step == 0 )
     {
       erase_used_update_history();
@@ -293,6 +292,8 @@ eprop_readout_bsshslm_2020::update( Time const& origin, const long from, const l
     }
 
     error_signal_buffer[ lag ] = S_.error_signal_;
+
+    create_eprop_history_entry( t );
 
     write_error_signal_to_history( t, S_.error_signal_ );
 

--- a/models/eprop_readout_bsshslm_2020.cpp
+++ b/models/eprop_readout_bsshslm_2020.cpp
@@ -293,7 +293,7 @@ eprop_readout_bsshslm_2020::update( Time const& origin, const long from, const l
 
     error_signal_buffer[ lag ] = S_.error_signal_;
 
-    create_eprop_history_entry( t );
+    emplace_new_eprop_history_entry( t );
 
     write_error_signal_to_history( t, S_.error_signal_ );
 

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -117,7 +117,6 @@ EpropArchivingNodeRecurrent::compute_arctan_surrogate_gradient( const double r,
   return gamma / M_PI * ( 1.0 / ( 1.0 + std::pow( beta * M_PI * ( v_m - v_th_adapt ), 2 ) ) );
 }
 
-
 void
 EpropArchivingNodeRecurrent::emplace_new_eprop_history_entry( const long time_step )
 {
@@ -128,7 +127,6 @@ EpropArchivingNodeRecurrent::emplace_new_eprop_history_entry( const long time_st
 
   eprop_history_.emplace_back( time_step, 0.0, 0.0 );
 }
-
 
 void
 EpropArchivingNodeRecurrent::write_surrogate_gradient_to_history( const long time_step,

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -117,6 +117,19 @@ EpropArchivingNodeRecurrent::compute_arctan_surrogate_gradient( const double r,
   return gamma / M_PI * ( 1.0 / ( 1.0 + std::pow( beta * M_PI * ( v_m - v_th_adapt ), 2 ) ) );
 }
 
+
+void
+EpropArchivingNodeRecurrent::create_eprop_history_entry( const long time_step )
+{
+  if ( eprop_indegree_ == 0 )
+  {
+    return;
+  }
+
+  eprop_history_.emplace_back( time_step, 0.0, 0.0 );
+}
+
+
 void
 EpropArchivingNodeRecurrent::write_surrogate_gradient_to_history( const long time_step,
   const double surrogate_gradient )
@@ -126,7 +139,8 @@ EpropArchivingNodeRecurrent::write_surrogate_gradient_to_history( const long tim
     return;
   }
 
-  eprop_history_.emplace_back( time_step, surrogate_gradient, 0.0 );
+  auto it_hist = get_eprop_history( time_step );
+  it_hist->surrogate_gradient_ = surrogate_gradient;
 }
 
 void
@@ -261,6 +275,19 @@ EpropArchivingNodeReadout::EpropArchivingNodeReadout( const EpropArchivingNodeRe
 }
 
 void
+EpropArchivingNodeReadout::create_eprop_history_entry( const long time_step, const bool has_norm_step )
+{
+  if ( eprop_indegree_ == 0 )
+  {
+    return;
+  }
+
+  const long shift = has_norm_step ? delay_out_norm_ : 0;
+
+  eprop_history_.emplace_back( time_step - shift, 5.0 );
+}
+
+void
 EpropArchivingNodeReadout::write_error_signal_to_history( const long time_step,
   const double error_signal,
   const bool has_norm_step )
@@ -272,7 +299,8 @@ EpropArchivingNodeReadout::write_error_signal_to_history( const long time_step,
 
   const long shift = has_norm_step ? delay_out_norm_ : 0;
 
-  eprop_history_.emplace_back( time_step - shift, error_signal );
+  auto it_hist = get_eprop_history( time_step - shift );
+  it_hist->error_signal_ = error_signal;
 }
 
 

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -119,7 +119,7 @@ EpropArchivingNodeRecurrent::compute_arctan_surrogate_gradient( const double r,
 
 
 void
-EpropArchivingNodeRecurrent::create_eprop_history_entry( const long time_step )
+EpropArchivingNodeRecurrent::emplace_new_eprop_history_entry( const long time_step )
 {
   if ( eprop_indegree_ == 0 )
   {
@@ -275,7 +275,7 @@ EpropArchivingNodeReadout::EpropArchivingNodeReadout( const EpropArchivingNodeRe
 }
 
 void
-EpropArchivingNodeReadout::create_eprop_history_entry( const long time_step, const bool has_norm_step )
+EpropArchivingNodeReadout::emplace_new_eprop_history_entry( const long time_step, const bool has_norm_step )
 {
   if ( eprop_indegree_ == 0 )
   {

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -190,7 +190,10 @@ public:
     const double beta,
     const double gamma );
 
-  //! Create an entry in the eprop history for the given time step and surrogate gradient.
+  //! Create an entry in the eprop history for the given time step.
+  void create_eprop_history_entry( const long time_step );
+
+  //! Write the given surrogate gradient value to the history at the given time step.
   void write_surrogate_gradient_to_history( const long time_step, const double surrogate_gradient );
 
   //! Update the learning signal in the eprop history entry of the given time step by writing the value of the incoming
@@ -264,7 +267,10 @@ public:
   //! Copy constructor.
   EpropArchivingNodeReadout( const EpropArchivingNodeReadout& );
 
-  //! Create an entry in the eprop history for the given time step and error signal.
+  //! Create an entry in the eprop history for the given time step.
+  void create_eprop_history_entry( const long time_step, const bool has_norm_step = true );
+
+  //! Write the given error signal value to history at the given time step.
   void
   write_error_signal_to_history( const long time_step, const double error_signal, const bool has_norm_step = true );
 };

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -190,8 +190,8 @@ public:
     const double beta,
     const double gamma );
 
-  //! Create an entry in the eprop history for the given time step.
-  void create_eprop_history_entry( const long time_step );
+  //! Create an eprop history entry and append it to the eprop history for the given time step.
+  void emplace_new_eprop_history_entry( const long time_step );
 
   //! Write the given surrogate gradient value to the history at the given time step.
   void write_surrogate_gradient_to_history( const long time_step, const double surrogate_gradient );
@@ -268,7 +268,7 @@ public:
   EpropArchivingNodeReadout( const EpropArchivingNodeReadout& );
 
   //! Create an entry in the eprop history for the given time step.
-  void create_eprop_history_entry( const long time_step, const bool has_norm_step = true );
+  void emplace_new_eprop_history_entry( const long time_step, const bool has_norm_step = true );
 
   //! Write the given error signal value to history at the given time step.
   void

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -190,7 +190,7 @@ public:
     const double beta,
     const double gamma );
 
-  //! Create an eprop history entry for the given time step and append it to the eprop history.
+  //! Create an entry for the given time step at the end of the eprop history.
   void emplace_new_eprop_history_entry( const long time_step );
 
   //! Write the given surrogate gradient value to the history at the given time step.
@@ -267,7 +267,7 @@ public:
   //! Copy constructor.
   EpropArchivingNodeReadout( const EpropArchivingNodeReadout& );
 
-  //! Create an eprop history entry for the given time step and append it to the eprop history.
+  //! Create an entry for the given time step at the end of the eprop history.
   void emplace_new_eprop_history_entry( const long time_step, const bool has_norm_step = true );
 
   //! Write the given error signal value to history at the given time step.

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -190,7 +190,7 @@ public:
     const double beta,
     const double gamma );
 
-  //! Create an eprop history entry and append it to the eprop history for the given time step.
+  //! Create an eprop history entry for the given time step and append it to the eprop history.
   void emplace_new_eprop_history_entry( const long time_step );
 
   //! Write the given surrogate gradient value to the history at the given time step.
@@ -267,7 +267,7 @@ public:
   //! Copy constructor.
   EpropArchivingNodeReadout( const EpropArchivingNodeReadout& );
 
-  //! Create an entry in the eprop history for the given time step.
+  //! Create an eprop history entry for the given time step and append it to the eprop history.
   void emplace_new_eprop_history_entry( const long time_step, const bool has_norm_step = true );
 
   //! Write the given error signal value to history at the given time step.


### PR DESCRIPTION
This PR alleviates the inconsistency between the functions `write_surrogate_gradient_to_history`, `write_error_signal_to_history`, `write_learning_signal_to_history`, and the imprecise names of the first two. The first two write the corresponding value to the history and create the history entry, whereas the third writes to existing entries.

Note that `write_update_to_history`  and one of the overloaded `write_firing_rate_to_history` also create history entries, which can be maybe specified in the function's name.

While this new logic disentangles the creation and writing of the history entries, the old logic is more efficient. Thus, I would be happy with either solution.