### PR TITLE
Fix usage of write_upate_to_history()

### DIFF
--- a/models/eprop_synapse.h
+++ b/models/eprop_synapse.h
@@ -440,7 +440,7 @@ eprop_synapse< targetidentifierT >::check_connection( Node& s,
   ConnTestDummyNode dummy_target;
   ConnectionBase::check_connection_( dummy_target, s, t, receptor_type );
 
-  t.register_eprop_connection();
+  t.register_eprop_connection( false );
 
   optimizer_ = cp.optimizer_cp_->get_optimizer();
 }
@@ -469,7 +469,7 @@ eprop_synapse< targetidentifierT >::send( Event& e, size_t thread, const EpropSy
   }
 
   const long eprop_isi_trace_cutoff = target->get_eprop_isi_trace_cutoff();
-  target->write_update_to_history( t_previous_spike_, t_spike, eprop_isi_trace_cutoff, true );
+  target->write_update_to_history( t_previous_spike_, t_spike, eprop_isi_trace_cutoff, false );
 
   t_previous_spike_ = t_spike;
 

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -56,7 +56,7 @@ public:
   EpropArchivingNode( const EpropArchivingNode& );
 
   //! Initialize the update history and register the eprop synapse.
-  void register_eprop_connection() override;
+  void register_eprop_connection( const bool is_bsshslm_2020_model = true ) override;
 
   //! Register current update in the update history and deregister previous update.
   void write_update_to_history( const long t_previous_update,

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -217,7 +217,7 @@ Node::register_stdp_connection( double, double )
 }
 
 void
-Node::register_eprop_connection()
+Node::register_eprop_connection( const bool )
 {
   throw IllegalConnection( "The target node does not support eprop synapses." );
 }
@@ -232,7 +232,7 @@ void
 Node::write_update_to_history( const long t_previous_update,
   const long t_current_update,
   const long eprop_isi_trace_cutoff,
-  const bool clean )
+  const bool is_bsshslm_2020_model )
 {
   throw IllegalConnection( "The target node is not an e-prop neuron." );
 }

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -488,7 +488,7 @@ public:
    *
    * @throws IllegalConnection
    */
-  virtual void register_eprop_connection();
+  virtual void register_eprop_connection( const bool is_bsshslm_2020_model = true );
 
   /**
    * Get the number of steps the time-point of the signal has to be shifted to
@@ -511,7 +511,7 @@ public:
   virtual void write_update_to_history( const long t_previous_update,
     const long t_current_update,
     const long eprop_isi_trace_cutoff = 0,
-    const bool clean = false );
+    const bool is_bsshslm_2020_model = true );
 
   /**
    * Get maximum number of time steps integrated between two consecutive spikes.


### PR DESCRIPTION
**Objective of the PR:**

This pull request addresses discrepancies in the usage of the function `EpropArchivingNode<HistEntryT>::write_update_to_history` between the `bsshslm_2020` models and other models.

**Discrepancy:**

1. **bsshslm_2020 Models:**
   - These models provide update intervals to `write_update_to_history` that are relative to the neurons' timelines. To align these times with the origin, an adjustment via the addition of `shift` is necessary.

2. **Non-bsshslm_2020 Models:**
   - These models input spike times directly to `write_update_to_history`. Since the spike times are already aligned with the origin, adding `shift` is not only unnecessary but also causes adverse effects. Specifically, it results in the accidental deletion of extra `eprop_history_` entries each time `erase_used_eprop_history` is triggered. This deletion leads to misalignment of the archive entries with respect to the spiking variables used during the `compute_gradient` function.

This issue went undetected previously due to:
   - [1] The sine-waves task was primarily used during development. This task features lazy neuron activity within a non-sparsely connected network (so every neuron has the lazy ones at the presynaptic end), which meant that the archive was seldom cleared sufficiently for any single neuron, masking the underlying problem.
   - [2] The function `std::lower_bound()` employed in `get_eprop_history(const long time_step)` returns the first entry where `t_ >= time_step`. Consequently, no significant errors were observed even when an exact match for `t_ == time_step` was not found, further obscuring the issue.
   - [3] The impact of the problem on learning performance is minimal, thanks to the network's inherent robustness to shifts in data.

**Proposed Solution:**

To effectively manage these divergent cases, I propose the following modifications:

1. Introduce a boolean variable `is_bsshslm_2020_model` in both `register_eprop_connection` and `write_update_to_history` functions. This variable will enable the program to differentiate and appropriately handle the updates based on the model type.

2. Modify the parameters used to log updates in the history from using `t_previous_spike` and `t_spike` directly to using adjusted times `t_previous_spike - delay_rec_out` and `t_spike - delay_rec_out`. This change ensures that the intended region of `eprop_history` (initially `[t_previous_spike, t_spike)`) is correctly mapped to `[t_previous_spike - delay_rec_out, t_spike - delay_rec_out)`, as depicted in Figure 1.

<img src="https://github.com/JesusEV/nest-simulator/assets/43375826/07b2a6c0-eb72-4825-bbd9-b195784c16bd" width="40%" alt="PR Image">


**FIGURE 1** remark: The `write_learning_signal_to_history` function aligns `L^t` with `psi^t` in the `eprop_archive`
