### PR TITLE
Refactor buffering of spiking variable

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -378,8 +378,8 @@ eprop_iaf::handle( DataLoggingRequest& e )
 
 void
 eprop_iaf::compute_gradient( const long t_spike,
-  const long t_previous_spike,
-  double& previous_z_buffer,
+  const long t_spike_previous,
+  double& z_previous_buffer,
   double& z_bar,
   double& e_bar,
   double& epsilon,
@@ -387,24 +387,23 @@ eprop_iaf::compute_gradient( const long t_spike,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
-  long t = t_previous_spike; // inter-spike time step
-  double e = 0.0;            // eligibility trace
-  double z = 0.0;            // spiking variable
-  double psi = 0.0;          // surrogate gradient
-  double L = 0.0;            // learning signal
-  double grad = 0.0;         // gradient
+  double e = 0.0;                // eligibility trace
+  double z = 0.0;                // spiking variable
+  double z_current_buffer = 1.0; // buffer containing the spike that triggered the current integration
+  double psi = 0.0;              // surrogate gradient
+  double L = 0.0;                // learning signal
+  double grad = 0.0;             // gradient
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
-  auto eprop_hist_it = get_eprop_history( t_previous_spike - 1 );
+  auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  double pre = 1.0;
-
-  while ( t < std::min( t_spike, t_previous_spike + P_.eprop_isi_trace_cutoff_ ) )
+  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+        ++t, ++eprop_hist_it )
   {
-    z = previous_z_buffer;
-    previous_z_buffer = pre;
-    pre = 0.0;
+    z = z_previous_buffer;
+    z_previous_buffer = z_current_buffer;
+    z_current_buffer = 0.0;
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;
@@ -415,12 +414,9 @@ eprop_iaf::compute_gradient( const long t_spike,
     grad = L * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
-
-    ++eprop_hist_it;
-    ++t;
   }
 
-  const int power = t_spike - ( t_previous_spike + P_.eprop_isi_trace_cutoff_ );
+  const int power = t_spike - ( t_spike_previous + P_.eprop_isi_trace_cutoff_ );
 
   if ( power > 0 )
   {

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -398,8 +398,9 @@ eprop_iaf::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
-        ++t, ++eprop_hist_it )
+  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+
+  for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -279,8 +279,8 @@ public:
   void set_status( const DictionaryDatum& ) override;
 
   void compute_gradient( const long t_spike,
-    const long t_previous_spike,
-    double& previous_z_buffer,
+    const long t_spike_previous,
+    double& z_previous_buffer,
     double& z_bar,
     double& e_bar,
     double& epsilon,

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -416,8 +416,8 @@ eprop_iaf_adapt::handle( DataLoggingRequest& e )
 
 void
 eprop_iaf_adapt::compute_gradient( const long t_spike,
-  const long t_previous_spike,
-  double& previous_z_buffer,
+  const long t_spike_previous,
+  double& z_previous_buffer,
   double& z_bar,
   double& e_bar,
   double& epsilon,
@@ -425,24 +425,23 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
-  long t = t_previous_spike; // inter-spike time step
-  double e = 0.0;            // eligibility trace
-  double z = 0.0;            // spiking variable
-  double psi = 0.0;          // surrogate gradient
-  double L = 0.0;            // learning signal
-  double grad = 0.0;         // gradient
+  double e = 0.0;                // eligibility trace
+  double z = 0.0;                // spiking variable
+  double z_current_buffer = 1.0; // buffer containing the spike that triggered the current integration
+  double psi = 0.0;              // surrogate gradient
+  double L = 0.0;                // learning signal
+  double grad = 0.0;             // gradient
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
-  auto eprop_hist_it = get_eprop_history( t_previous_spike - 1 );
+  auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  double pre = 1.0;
-
-  while ( t < std::min( t_spike, t_previous_spike + P_.eprop_isi_trace_cutoff_ ) )
+  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+        ++t, ++eprop_hist_it )
   {
-    z = previous_z_buffer;
-    previous_z_buffer = pre;
-    pre = 0.0;
+    z = z_previous_buffer;
+    z_previous_buffer = z_current_buffer;
+    z_current_buffer = 0.0;
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;
@@ -454,12 +453,9 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
     grad = L * e_bar;
 
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t, grad, weight );
-
-    ++eprop_hist_it;
-    ++t;
   }
 
-  const int power = t_spike - ( t_previous_spike + P_.eprop_isi_trace_cutoff_ );
+  const int power = t_spike - ( t_spike_previous + P_.eprop_isi_trace_cutoff_ );
 
   if ( power > 0 )
   {

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -436,8 +436,9 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
-        ++t, ++eprop_hist_it )
+  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+
+  for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -296,8 +296,8 @@ public:
   void set_status( const DictionaryDatum& ) override;
 
   void compute_gradient( const long t_spike,
-    const long t_previous_spike,
-    double& previous_z_buffer,
+    const long t_spike_previous,
+    double& z_previous_buffer,
     double& z_bar,
     double& e_bar,
     double& epsilon,

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -481,8 +481,9 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
-        ++t, ++eprop_hist_it )
+  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+
+  for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -181,8 +181,8 @@ public:
   void set_status( const DictionaryDatum& ) override;
 
   void compute_gradient( const long t_spike,
-    const long t_previous_spike,
-    double& previous_z_buffer,
+    const long t_spike_previous,
+    double& z_previous_buffer,
     double& z_bar,
     double& e_bar,
     double& epsilon,

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -348,8 +348,9 @@ eprop_readout::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  for ( long t = t_spike_previous; t < std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
-        ++t, ++eprop_hist_it )
+  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+
+  for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -230,8 +230,8 @@ public:
   void set_status( const DictionaryDatum& ) override;
 
   void compute_gradient( const long t_spike,
-    const long t_previous_spike,
-    double& previous_z_buffer,
+    const long t_spike_previous,
+    double& z_previous_buffer,
     double& z_bar,
     double& e_bar,
     double& epsilon,

--- a/models/eprop_synapse.h
+++ b/models/eprop_synapse.h
@@ -304,7 +304,7 @@ private:
   double weight_;
 
   //! The time step when the previous spike arrived.
-  long t_previous_spike_;
+  long t_spike_previous_;
 
   //! The time step when the spike arrived that triggered the previous e-prop update.
   long t_previous_trigger_spike_;
@@ -323,8 +323,7 @@ private:
   double z_bar_ = 0.0;
   double e_bar_ = 0.0;
   double epsilon_ = 0.0;
-
-  double previous_z_buffer_ = 0.0;
+  double z_previous_buffer_ = 0.0;
 };
 
 template < typename targetidentifierT >
@@ -348,7 +347,7 @@ template < typename targetidentifierT >
 eprop_synapse< targetidentifierT >::eprop_synapse()
   : ConnectionBase()
   , weight_( 1.0 )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_trigger_spike_( 0 )
   , optimizer_( nullptr )
 {
@@ -365,7 +364,7 @@ template < typename targetidentifierT >
 eprop_synapse< targetidentifierT >::eprop_synapse( const eprop_synapse& es )
   : ConnectionBase( es )
   , weight_( es.weight_ )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_trigger_spike_( 0 )
   , optimizer_( es.optimizer_ )
 {
@@ -384,7 +383,7 @@ eprop_synapse< targetidentifierT >::operator=( const eprop_synapse& es )
   ConnectionBase::operator=( es );
 
   weight_ = es.weight_;
-  t_previous_spike_ = es.t_previous_spike_;
+  t_spike_previous_ = es.t_spike_previous_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
   optimizer_ = es.optimizer_;
 
@@ -395,7 +394,7 @@ template < typename targetidentifierT >
 eprop_synapse< targetidentifierT >::eprop_synapse( eprop_synapse&& es )
   : ConnectionBase( es )
   , weight_( es.weight_ )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_trigger_spike_( 0 )
   , optimizer_( es.optimizer_ )
 {
@@ -415,7 +414,7 @@ eprop_synapse< targetidentifierT >::operator=( eprop_synapse&& es )
   ConnectionBase::operator=( es );
 
   weight_ = es.weight_;
-  t_previous_spike_ = es.t_previous_spike_;
+  t_spike_previous_ = es.t_spike_previous_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
 
   optimizer_ = es.optimizer_;
@@ -462,16 +461,16 @@ eprop_synapse< targetidentifierT >::send( Event& e, size_t thread, const EpropSy
 
   const long t_spike = e.get_stamp().get_steps();
 
-  if ( t_previous_spike_ != 0 )
+  if ( t_spike_previous_ != 0 )
   {
     target->compute_gradient(
-      t_spike, t_previous_spike_, previous_z_buffer_, z_bar_, e_bar_, epsilon_, weight_, cp, optimizer_ );
+      t_spike, t_spike_previous_, z_previous_buffer_, z_bar_, e_bar_, epsilon_, weight_, cp, optimizer_ );
   }
 
   const long eprop_isi_trace_cutoff = target->get_eprop_isi_trace_cutoff();
-  target->write_update_to_history( t_previous_spike_, t_spike, eprop_isi_trace_cutoff, true );
+  target->write_update_to_history( t_spike_previous_, t_spike, eprop_isi_trace_cutoff, true );
 
-  t_previous_spike_ = t_spike;
+  t_spike_previous_ = t_spike;
 
   e.set_receiver( *target );
   e.set_weight( weight_ );

--- a/models/eprop_synapse_bsshslm_2020.h
+++ b/models/eprop_synapse_bsshslm_2020.h
@@ -312,7 +312,7 @@ private:
   double weight_;
 
   //! The time step when the previous spike arrived.
-  long t_previous_spike_;
+  long t_spike_previous_;
 
   //! The time step when the previous e-prop update was.
   long t_previous_update_;
@@ -364,7 +364,7 @@ template < typename targetidentifierT >
 eprop_synapse_bsshslm_2020< targetidentifierT >::eprop_synapse_bsshslm_2020()
   : ConnectionBase()
   , weight_( 1.0 )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_update_( 0 )
   , t_next_update_( 0 )
   , t_previous_trigger_spike_( 0 )
@@ -386,7 +386,7 @@ template < typename targetidentifierT >
 eprop_synapse_bsshslm_2020< targetidentifierT >::eprop_synapse_bsshslm_2020( const eprop_synapse_bsshslm_2020& es )
   : ConnectionBase( es )
   , weight_( es.weight_ )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_update_( 0 )
   , t_next_update_( kernel().simulation_manager.get_eprop_update_interval().get_steps() )
   , t_previous_trigger_spike_( 0 )
@@ -410,7 +410,7 @@ eprop_synapse_bsshslm_2020< targetidentifierT >::operator=( const eprop_synapse_
   ConnectionBase::operator=( es );
 
   weight_ = es.weight_;
-  t_previous_spike_ = es.t_previous_spike_;
+  t_spike_previous_ = es.t_spike_previous_;
   t_previous_update_ = es.t_previous_update_;
   t_next_update_ = es.t_next_update_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
@@ -426,7 +426,7 @@ template < typename targetidentifierT >
 eprop_synapse_bsshslm_2020< targetidentifierT >::eprop_synapse_bsshslm_2020( eprop_synapse_bsshslm_2020&& es )
   : ConnectionBase( es )
   , weight_( es.weight_ )
-  , t_previous_spike_( 0 )
+  , t_spike_previous_( 0 )
   , t_previous_update_( 0 )
   , t_next_update_( es.t_next_update_ )
   , t_previous_trigger_spike_( 0 )
@@ -451,7 +451,7 @@ eprop_synapse_bsshslm_2020< targetidentifierT >::operator=( eprop_synapse_bsshsl
   ConnectionBase::operator=( es );
 
   weight_ = es.weight_;
-  t_previous_spike_ = es.t_previous_spike_;
+  t_spike_previous_ = es.t_spike_previous_;
   t_previous_update_ = es.t_previous_update_;
   t_next_update_ = es.t_next_update_;
   t_previous_trigger_spike_ = es.t_previous_trigger_spike_;
@@ -519,10 +519,10 @@ eprop_synapse_bsshslm_2020< targetidentifierT >::send( Event& e,
     t_previous_trigger_spike_ = t_spike;
   }
 
-  if ( t_previous_spike_ > 0 )
+  if ( t_spike_previous_ > 0 )
   {
     const long t = t_spike >= t_next_update_ + shift ? t_next_update_ + shift : t_spike;
-    presyn_isis_.push_back( t - t_previous_spike_ );
+    presyn_isis_.push_back( t - t_spike_previous_ );
   }
 
   if ( t_spike > t_next_update_ + shift )
@@ -543,7 +543,7 @@ eprop_synapse_bsshslm_2020< targetidentifierT >::send( Event& e,
     t_previous_trigger_spike_ = t_spike;
   }
 
-  t_previous_spike_ = t_spike;
+  t_spike_previous_ = t_spike;
 
   e.set_receiver( *target );
   e.set_weight( weight_ );

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -552,8 +552,8 @@ nest::Node::get_tau_syn_in( int )
 
 void
 nest::Node::compute_gradient( const long t_spike,
-  const long t_previous_spike,
-  double& previous_z_buffer,
+  const long t_spike_previous,
+  double& z_previous_buffer,
   double& z_bar,
   double& e_bar,
   double& epsilon,

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -822,8 +822,8 @@ public:
    * @params presyn_isis  is cleared during call
    */
   virtual void compute_gradient( const long t_spike,
-    const long t_previous_spike,
-    double& previous_z_buffer,
+    const long t_spike_previous,
+    double& z_previous_buffer,
     double& z_bar,
     double& e_bar,
     double& epsilon,


### PR DESCRIPTION
This PR aims to clarify the buffering of the spiking variable `z` in the `compute_gradient_function` and comprises the following changes:

1. rename `t_previous_spike` to `t_spike_previous` to emphasize the relationship to `t_spike`
2. rename `previous_z_buffer` to `z_previous_buffer` and `pre` to `z_current_buffer` to emphasize the relationship to `z`
3. replace the `while` loop with a `for` loop in which `t` is locally defined and `eprop_hist_it` and `t` are incremented
4. change the position of `t_spike` and `t_spike_previous + P_.eprop_isi_trace_cutoff_` in `std::min` since `t_spike_previous` is chronologically earlier than `t_spike` (to enhance readability)