### PR TITLE
Make kappa independent of readout membrane time constant

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -81,7 +81,7 @@ eprop_iaf::Parameters_::Parameters_()
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
   , V_th_( -55.0 - E_L_ )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
+  , kappa_( 0.97 )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
 {
 }

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -85,7 +85,7 @@ eprop_iaf_adapt::Parameters_::Parameters_()
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
   , V_th_( -55.0 - E_L_ )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
+  , kappa_( 0.97 )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
 {
 }

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -86,7 +86,7 @@ nest::eprop_iaf_psc_delta::Parameters_::Parameters_()
   , beta_( 1.0 )
   , gamma_( 0.3 )
   , surrogate_gradient_function_( "piecewise_linear" )
-  , kappa_( std::exp( -Time::get_resolution().get_ms() / 10.0 ) )
+  , kappa_( 0.97 )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
 {
 }

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_classification_evidence-accumulation.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_classification_evidence-accumulation.py
@@ -211,9 +211,7 @@ params_nrn_reg = {
     "tau_m": 20.0,
     "V_m": 0.0,
     "V_th": 0.6,  # mV, spike threshold membrane voltage
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
+    "kappa": 0.97,  # low-pass filter of the eligibility trace
 }
 
 if model_nrn_reg == "eprop_iaf_psc_delta":
@@ -239,7 +237,7 @@ params_nrn_ad = {
     "tau_m": 20.0,
     "V_m": 0.0,
     "V_th": 0.6,
-    "kappa": np.exp(-duration["step"] / params_nrn_out["tau_m"]),
+    "kappa": 0.97,
 }
 
 params_nrn_ad["adapt_beta"] = 1.7 * (

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_neuromorphic_mnist.py
@@ -211,9 +211,7 @@ params_nrn_rec = {
     "V_m": 0.0,  # mV, initial value of the membrane voltage
     "V_th": 0.5,  # mV, spike threshold membrane voltage
     "V_reset": -0.5,  # mV, reset membrane voltage
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
+    "kappa": 0.99,  # low-pass filter of the eligibility trace
 }
 
 if model_nrn_rec == "eprop_iaf":

--- a/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/online_eprop_supervised_regression_sine-waves.py
@@ -191,9 +191,7 @@ params_nrn_rec = {
     "tau_m": 30.0,
     "V_m": 0.0,
     "V_th": 0.03,  # mV, spike threshold membrane voltage
-    "kappa": np.exp(
-        -duration["step"] / params_nrn_out["tau_m"]
-    ),  # ms, for technical reasons pass a filter with the readout neuron membrane time constant
+    "kappa": 0.97,  # low-pass filter of the eligibility trace
 }
 
 if model_nrn_rec == "eprop_iaf_psc_delta":


### PR DESCRIPTION
This PR aims to make clear that in the new e-prop models the eligibility trace low-pass filter can be chosen by the user and is independent of the readout membrane time constant.