### PR TITLE
Add generalization of delays between recurrent and readout layers

### DIFF
--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -285,6 +285,7 @@ public:
     double& e_bar,
     double& epsilon,
     double& weight,
+    std::queue< double >& pre_syn_buffer,      
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
@@ -295,6 +296,9 @@ public:
 
   //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
+
+  //! Get sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+  long get_delay_total() const override;  
 
 protected:
   void init_buffers_() override;
@@ -358,6 +362,15 @@ private:
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.
     long eprop_isi_trace_cutoff_;
+
+    //! Connection delay from recurrent to output neurons.
+    long delay_rec_out_;
+    
+    //! Broadcast delay of learning signals.
+    long delay_out_rec_;
+
+    //! Sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+    long delay_total_;
 
     //! Default constructor.
     Parameters_();
@@ -481,6 +494,12 @@ inline long
 eprop_iaf::get_eprop_isi_trace_cutoff()
 {
   return P_.eprop_isi_trace_cutoff_;
+}
+
+inline long
+eprop_iaf::get_delay_total() const
+{
+  return P_.delay_total_;
 }
 
 inline size_t

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -87,6 +87,9 @@ eprop_iaf_adapt::Parameters_::Parameters_()
   , V_th_( -55.0 - E_L_ )
   , kappa_( 0.97 )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
+  , delay_rec_out_(1)
+  , delay_out_rec_(1)
+  , delay_total_(1)     
 {
 }
 
@@ -137,6 +140,8 @@ eprop_iaf_adapt::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::V_th, V_th_ + E_L_ );
   def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
+  def< long >( d, names::delay_rec_out, delay_rec_out_);
+  def< long >( d, names::delay_out_rec, delay_out_rec_);      
 }
 
 double
@@ -169,7 +174,9 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
   updateValueParam< double >( d, names::kappa, kappa_, node );
   updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
-
+  updateValueParam< long >( d, names::delay_rec_out, delay_rec_out_, node );
+  updateValueParam< long >( d, names::delay_out_rec, delay_out_rec_, node );
+  
   if ( adapt_beta_ < 0 )
   {
     throw BadProperty( "Threshold adaptation prefactor adapt_beta ≥ 0 required." );
@@ -219,6 +226,18 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
   {
     throw BadProperty( "Cutoff of integration of eprop trace between spikes eprop_isi_trace_cutoff ≥ 0 required." );
   }
+
+  if ( delay_rec_out_ < 1 )
+  {
+    throw BadProperty( "Connection delay from recurrent to output neuron ≥ 1 required." );
+  }
+
+  if ( delay_out_rec_ < 1 )
+  {
+    throw BadProperty( "Broadcast delay of learning signals ≥ 1 required." );
+  }  
+
+  delay_total_ = delay_rec_out_ + ( delay_out_rec_ - 1 ); 
 
   return delta_EL;
 }
@@ -292,6 +311,8 @@ eprop_iaf_adapt::pre_run_hook()
   V_.RefractoryCounts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
 
   compute_surrogate_gradient = select_surrogate_gradient( P_.surrogate_gradient_function_ );
+  update_pre_syn_buffer = P_.delay_total_ == 1? &EpropArchivingNodeRecurrent::update_pre_syn_buffer_one_entry 
+                                            : &EpropArchivingNodeRecurrent::update_pre_syn_buffer_multiple_entries;
 
   // calculate the entries of the propagator matrix for the evolution of the state vector
 
@@ -301,6 +322,11 @@ eprop_iaf_adapt::pre_run_hook()
   V_.P_i_in_ = P_.tau_m_ / P_.C_m_ * ( 1.0 - V_.P_v_m_ );
   V_.P_z_in_ = P_.regular_spike_arrival_ ? 1.0 : 1.0 - V_.P_v_m_;
   V_.P_adapt_ = std::exp( -dt / P_.adapt_tau_ );
+
+  for ( long t = -P_.delay_total_; t < 0; ++t )
+  {
+    emplace_new_eprop_history_entry( t );
+  }
 }
 
 long
@@ -422,6 +448,7 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
   double& e_bar,
   double& epsilon,
   double& weight,
+  std::queue< double >& pre_syn_buffer,    
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
@@ -434,15 +461,13 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
-  auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
+  auto eprop_hist_it = get_eprop_history( t_spike_previous - P_.delay_total_ );
 
   const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    z = z_previous_buffer;
-    z_previous_buffer = z_current_buffer;
-    z_current_buffer = 0.0;
+    ( this->*update_pre_syn_buffer )(z, z_current_buffer, z_previous_buffer, pre_syn_buffer, t_spike, t);  
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -302,16 +302,20 @@ public:
     double& e_bar,
     double& epsilon,
     double& weight,
+    std::queue< double >& pre_syn_buffer,     
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
   void pre_run_hook() override;
-  long get_shift() const override;
+  long get_shift() const override;    
   bool is_eprop_recurrent_node() const override;
   void update( Time const&, const long, const long ) override;
 
   //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
+
+  //! Get sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+  long get_delay_total() const override;  
 
 protected:
   void init_buffers_() override;
@@ -381,6 +385,15 @@ private:
     //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.
     long eprop_isi_trace_cutoff_;
+
+    //! Connection delay from recurrent to output neurons.
+    long delay_rec_out_;
+
+    //! Broadcast delay of learning signals.
+    long delay_out_rec_;
+
+    //! Sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+    long delay_total_;
 
     //! Default constructor.
     Parameters_();
@@ -527,6 +540,12 @@ inline long
 eprop_iaf_adapt::get_eprop_isi_trace_cutoff()
 {
   return P_.eprop_isi_trace_cutoff_;
+}
+
+inline long
+eprop_iaf_adapt::get_delay_total() const
+{
+  return P_.delay_total_;
 }
 
 inline size_t

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -88,6 +88,9 @@ nest::eprop_iaf_psc_delta::Parameters_::Parameters_()
   , surrogate_gradient_function_( "piecewise_linear" )
   , kappa_( 0.97 )
   , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
+  , delay_rec_out_(1)
+  , delay_out_rec_(1)
+  , delay_total_(1)     
 {
 }
 
@@ -125,6 +128,8 @@ nest::eprop_iaf_psc_delta::Parameters_::get( DictionaryDatum& d ) const
   def< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_ );
   def< double >( d, names::kappa, kappa_ );
   def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
+  def< long >( d, names::delay_rec_out, delay_rec_out_);
+  def< long >( d, names::delay_out_rec, delay_out_rec_);      
 }
 
 double
@@ -178,6 +183,8 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
   updateValueParam< double >( d, names::kappa, kappa_, node );
   updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
+  updateValueParam< long >( d, names::delay_rec_out, delay_rec_out_, node );
+  updateValueParam< long >( d, names::delay_out_rec, delay_out_rec_, node );
 
   if ( V_reset_ >= V_th_ )
   {
@@ -216,6 +223,18 @@ nest::eprop_iaf_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* nod
   {
     throw BadProperty( "Cutoff of integration of eprop trace between spikes eprop_isi_trace_cutoff ≥ 0 required." );
   }
+
+  if ( delay_rec_out_ < 1 )
+  {
+    throw BadProperty( "Connection delay from recurrent to output neuron ≥ 1 required." );
+  }
+
+  if ( delay_out_rec_ < 1 )
+  {
+    throw BadProperty( "Broadcast delay of learning signals ≥ 1 required." );
+  }  
+
+  delay_total_ = delay_rec_out_ + ( delay_out_rec_ - 1 );   
 
   return delta_EL;
 }
@@ -290,6 +309,8 @@ nest::eprop_iaf_psc_delta::pre_run_hook()
   B_.logger_.init();
 
   compute_surrogate_gradient = select_surrogate_gradient( P_.surrogate_gradient_function_ );
+  update_pre_syn_buffer = P_.delay_total_ == 1? &EpropArchivingNodeRecurrent::update_pre_syn_buffer_one_entry 
+                                            : &EpropArchivingNodeRecurrent::update_pre_syn_buffer_multiple_entries;
 
   const double h = Time::get_resolution().get_ms();
 
@@ -320,6 +341,11 @@ nest::eprop_iaf_psc_delta::pre_run_hook()
   assert( V_.RefractoryCounts_ >= 0 );
 
   V_.P_z_in_ = 1.0;
+
+  for ( long t = -P_.delay_rec_out_; t < 0; ++t )
+  {
+    emplace_new_eprop_history_entry( t );
+  }
 }
 
 long
@@ -467,6 +493,7 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
   double& e_bar,
   double& epsilon,
   double& weight,
+  std::queue< double >& pre_syn_buffer,    
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {
@@ -479,15 +506,13 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
 
   const EpropSynapseCommonProperties& ecp = static_cast< const EpropSynapseCommonProperties& >( cp );
 
-  auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
+  auto eprop_hist_it = get_eprop_history( t_spike_previous - P_.delay_total_ );
 
   const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    z = z_previous_buffer;
-    z_previous_buffer = z_current_buffer;
-    z_current_buffer = 0.0;
+    ( this->*update_pre_syn_buffer )(z, z_current_buffer, z_previous_buffer, pre_syn_buffer, t_spike, t);  
 
     psi = eprop_hist_it->surrogate_gradient_;
     L = eprop_hist_it->learning_signal_;

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -187,6 +187,7 @@ public:
     double& e_bar,
     double& epsilon,
     double& weight,
+    std::queue< double >& pre_syn_buffer,     
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
@@ -197,6 +198,9 @@ public:
 
   //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
+
+  //! Get sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+  long get_delay_total() const override;  
 
 protected:
   void init_buffers_() override;
@@ -270,6 +274,15 @@ private:
     //!< Number of time steps integrated between two consecutive spikes is equal to the minimum between
     //!< eprop_isi_trace_cutoff_ and the inter-spike distance.
     long eprop_isi_trace_cutoff_;
+
+    //! Connection delay from recurrent to output neurons.
+    long delay_rec_out_;
+
+    //! Broadcast delay of learning signals.
+    long delay_out_rec_;
+
+    //! Sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+    long delay_total_;    
 
     Parameters_(); //!< Sets default parameter values
 
@@ -400,6 +413,12 @@ inline long
 eprop_iaf_psc_delta::get_eprop_isi_trace_cutoff()
 {
   return P_.eprop_isi_trace_cutoff_;
+}
+
+inline long
+eprop_iaf_psc_delta::get_delay_total() const
+{
+  return P_.delay_total_;
 }
 
 inline size_t

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -236,16 +236,20 @@ public:
     double& e_bar,
     double& epsilon,
     double& weight,
+    std::queue< double >& pre_syn_buffer,     
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
   void pre_run_hook() override;
-  long get_shift() const override;
+  long get_shift() const override; 
   bool is_eprop_recurrent_node() const override;
   void update( Time const&, const long, const long ) override;
 
   //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
+
+  //! Get sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+  long get_delay_total() const override;    
 
 protected:
   void init_buffers_() override;
@@ -288,6 +292,12 @@ private:
     //! eprop_isi_trace_cutoff_ and the inter-spike distance.
     long eprop_isi_trace_cutoff_;
 
+    //! Connection delay from recurrent to output neurons.
+    long delay_rec_out_;
+    
+    //! Broadcast delay of learning signals.
+    long delay_out_rec_;
+ 
     //! Default constructor.
     Parameters_();
 
@@ -330,6 +340,9 @@ private:
 
     //! Set the state variables.
     void set( const DictionaryDatum&, const Parameters_&, double, Node* );
+
+    //! Queue to hold last delay_out_rec error signals.
+    std::deque<double> error_signal_deque_;     
   };
 
   //! Structure of buffers.
@@ -426,6 +439,12 @@ inline long
 eprop_readout::get_eprop_isi_trace_cutoff()
 {
   return P_.eprop_isi_trace_cutoff_;
+}
+
+inline long
+eprop_readout::get_delay_total() const
+{
+  return P_.delay_rec_out_;
 }
 
 inline size_t

--- a/nestkernel/eprop_archiving_node.cpp
+++ b/nestkernel/eprop_archiving_node.cpp
@@ -151,11 +151,15 @@ EpropArchivingNodeRecurrent::write_learning_signal_to_history( const long time_s
     return;
   }
 
-  long shift = delay_rec_out_ + delay_out_rec_;
+  long shift = delay_out_rec_;
 
   if ( has_norm_step )
   {
-    shift += delay_out_norm_;
+    shift += delay_rec_out_ + delay_out_norm_;
+  }
+  else
+  {
+    shift += get_delay_total();
   }
 
 

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -82,6 +82,37 @@ public:
   //! the first update.
   void erase_used_eprop_history( const long eprop_isi_trace_cutoff );
 
+//! Update multiple entries in the presynaptic buffer. This function is used when the total synaptic delay
+//! is greater than one.
+void update_pre_syn_buffer_multiple_entries(double& z,
+  double& z_current_buffer,
+  double& z_previous_buffer,
+  std::queue<double>& pre_syn_buffer,
+  double t_spike,
+  double t);
+
+//! Update one entry in the presynaptic buffer. This function is used when the total synaptic delay
+//! is equal one.
+void update_pre_syn_buffer_one_entry(double& z,
+  double& z_current_buffer,
+  double& z_previous_buffer,
+  std::queue<double>& pre_syn_buffer,
+  double t_spike,
+  double t);
+
+//! This function pointer is dynamically assigned to handle either single or multiple buffer entry updates
+//! depending on the total synaptic delay.
+void (EpropArchivingNode< HistEntryT >::*update_pre_syn_buffer)(double& z,
+  double& z_current_buffer,
+  double& z_previous_buffer,
+  std::queue<double>& pre_syn_buffer,
+  double t_spike,
+  double t);
+
+//! Initialize the presynaptic buffer.
+void initialize_pre_syn_buffer(std::queue<double>& pre_syn_buffer) override;
+
+
 protected:
   //! Number of incoming eprop synapses
   size_t eprop_indegree_;

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -126,6 +126,8 @@ const Name dead_time( "dead_time" );
 const Name dead_time_random( "dead_time_random" );
 const Name dead_time_shape( "dead_time_shape" );
 const Name delay( "delay" );
+const Name delay_out_rec( "delay_out_rec" );
+const Name delay_rec_out( "delay_rec_out" );
 const Name delay_u_bars( "delay_u_bars" );
 const Name deliver_interval( "deliver_interval" );
 const Name delta( "delta" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -153,6 +153,8 @@ extern const Name dead_time;
 extern const Name dead_time_random;
 extern const Name dead_time_shape;
 extern const Name delay;
+extern const Name delay_out_rec;
+extern const Name delay_rec_out;
 extern const Name delay_u_bars;
 extern const Name deliver_interval;
 extern const Name delta;

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -228,6 +228,18 @@ Node::get_shift() const
   throw IllegalConnection( "The target node is not an e-prop neuron." );
 }
 
+long
+Node::get_delay_total() const
+{
+  throw IllegalConnection( "The target node is not an e-prop neuron." );
+}
+
+void
+Node::initialize_pre_syn_buffer( std::queue< double >& pre_syn_buffer )
+{
+  throw IllegalConnection( "The target node is not an e-prop neuron." );
+}
+
 void
 Node::write_update_to_history( const long t_previous_update,
   const long t_current_update,
@@ -558,6 +570,7 @@ nest::Node::compute_gradient( const long t_spike,
   double& e_bar,
   double& epsilon,
   double& weight,
+  std::queue< double >& pre_syn_buffer,    
   const CommonSynapseProperties& cp,
   WeightOptimizer* optimizer )
 {

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -26,6 +26,7 @@
 // C++ includes:
 #include <bitset>
 #include <deque>
+#include <queue>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -504,6 +505,14 @@ public:
   virtual long get_shift() const;
 
   /**
+   * Get sum of broadcast delay of learning signals and connection delay from recurrent to output neurons.
+   *
+   * @throws IllegalConnection
+   */
+  
+  virtual long get_delay_total() const;
+  
+  /**
    * Register current update in the update history and deregister previous update.
    *
    * @throws IllegalConnection
@@ -531,6 +540,8 @@ public:
    * @throws IllegalConnection
    */
   virtual bool is_eprop_recurrent_node() const;
+
+  virtual void initialize_pre_syn_buffer( std::queue< double >& pre_syn_buffer );    
 
 
   /**
@@ -828,6 +839,7 @@ public:
     double& e_bar,
     double& epsilon,
     double& weight,
+    std::queue< double >& pre_syn_buffer,    
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer );
 


### PR DESCRIPTION
This PR proposal aims to enhance the flexibility of delays between the recurrent-to-readout and readout-to-recurrent layers.

### TODOs:

- [ ] Discuss the necessity of defining `delay_rec_out` and `delay_out_rec` as configurable parameters in neuron models.
- [ ] Address potential conflicts between the parameters `delay_rec_out`, `delay_out_rec` and the hardcoded equivalents in `eprop_archiving_node`.
- [ ] Consult with the HEP on optimal strategies for buffering learning signals when `delay_out_rec > 1`.
- [ ] Review the function pointer `*update_pre_syn_buffer` and its parameters for potential improvements.
- [ ] Complete the missing items in the documentation.
