### PR TITLE
Remove irregular spike arrival

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -75,7 +75,6 @@ eprop_iaf::Parameters_::Parameters_()
   , beta_( 1.0 )
   , gamma_( 0.3 )
   , I_e_( 0.0 )
-  , regular_spike_arrival_( true )
   , surrogate_gradient_function_( "piecewise_linear" )
   , t_ref_( 2.0 )
   , tau_m_( 10.0 )
@@ -122,7 +121,6 @@ eprop_iaf::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::beta, beta_ );
   def< double >( d, names::gamma, gamma_ );
   def< double >( d, names::I_e, I_e_ );
-  def< bool >( d, names::regular_spike_arrival, regular_spike_arrival_ );
   def< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_ );
   def< double >( d, names::t_ref, t_ref_ );
   def< double >( d, names::tau_m, tau_m_ );
@@ -155,7 +153,6 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< double >( d, names::beta, beta_, node );
   updateValueParam< double >( d, names::gamma, gamma_, node );
   updateValueParam< double >( d, names::I_e, I_e_, node );
-  updateValueParam< bool >( d, names::regular_spike_arrival, regular_spike_arrival_, node );
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
   updateValueParam< double >( d, names::t_ref, t_ref_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
@@ -274,7 +271,6 @@ eprop_iaf::pre_run_hook()
 
   V_.P_v_m_ = std::exp( -dt / P_.tau_m_ );
   V_.P_i_in_ = P_.tau_m_ / P_.C_m_ * ( 1.0 - V_.P_v_m_ );
-  V_.P_z_in_ = P_.regular_spike_arrival_ ? 1.0 : 1.0 - V_.P_v_m_;
 }
 
 long
@@ -307,8 +303,7 @@ eprop_iaf::update( Time const& origin, const long from, const long to )
 
     S_.z_in_ = B_.spikes_.get_value( lag );
 
-    S_.v_m_ = V_.P_i_in_ * S_.i_in_ + V_.P_z_in_ * S_.z_in_ + V_.P_v_m_ * S_.v_m_;
-    S_.v_m_ -= P_.V_th_ * S_.z_;
+    S_.v_m_ = V_.P_i_in_ * S_.i_in_ + S_.z_in_ + V_.P_v_m_ * S_.v_m_;
     S_.v_m_ = std::max( S_.v_m_, P_.V_min_ );
 
     S_.z_ = 0.0;
@@ -321,6 +316,7 @@ eprop_iaf::update( Time const& origin, const long from, const long to )
       kernel().event_delivery_manager.send( *this, se, lag );
 
       S_.z_ = 1.0;
+      S_.v_m_ -= P_.V_th_ * S_.z_;
       S_.r_ = V_.RefractoryCounts_;
     }
 
@@ -415,7 +411,7 @@ eprop_iaf::compute_gradient( const long t_spike,
     L = eprop_hist_it->learning_signal_;
     firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
-    z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
+    z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -413,7 +413,7 @@ eprop_iaf::compute_gradient( const long t_spike,
 
     z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * z_bar;
-    e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
+    e_bar = P_.kappa_ * e_bar + e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;
 
     if ( optimize_each_step )

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -215,10 +215,6 @@ Parameter                   Unit    Math equivalent         Default          Des
 ``C_m``                     pF      :math:`C_\text{m}`                 250.0 Capacitance of the membrane
 ``E_L``                     mV      :math:`E_\text{L}`                 -70.0 Leak / resting membrane potential
 ``I_e``                     pA      :math:`I_\text{e}`                   0.0 Constant external input current
-``regular_spike_arrival``   Boolean                                 ``True`` If ``True``, the input spikes
-                                                                             arrive at the end of the time step,
-                                                                             if ``False`` at the beginning
-                                                                             (determines PSC scale)
 ``t_ref``                   ms      :math:`t_\text{ref}`                 2.0 Duration of the refractory period
 ``tau_m``                   ms      :math:`\tau_\text{m}`               10.0 Time constant of the membrane
 ``V_min``                   mV      :math:`v_\text{min}`    negative maximum Absolute lower bound of the
@@ -440,9 +436,6 @@ private:
     //! Constant external input current (pA).
     double I_e_;
 
-    //! If True, the input spikes arrive at the beginning of the time step, if False at the end (determines PSC scale).
-    bool regular_spike_arrival_;
-
     //! Surrogate gradient / pseudo-derivative function of the membrane voltage ["piecewise_linear", "exponential",
     //! "fast_sigmoid_derivative", "arctan"]
     std::string surrogate_gradient_function_;
@@ -536,10 +529,6 @@ private:
   {
     //! Propagator matrix entry for evolving the membrane voltage (mathematical symbol "alpha" in user documentation).
     double P_v_m_;
-
-    //! Propagator matrix entry for evolving the incoming spike state variables (mathematical symbol "zeta" in user
-    //! documentation).
-    double P_z_in_;
 
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -79,7 +79,6 @@ eprop_iaf_adapt::Parameters_::Parameters_()
   , beta_( 1.0 )
   , gamma_( 0.3 )
   , I_e_( 0.0 )
-  , regular_spike_arrival_( true )
   , surrogate_gradient_function_( "piecewise_linear" )
   , t_ref_( 2.0 )
   , tau_m_( 10.0 )
@@ -130,7 +129,6 @@ eprop_iaf_adapt::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::beta, beta_ );
   def< double >( d, names::gamma, gamma_ );
   def< double >( d, names::I_e, I_e_ );
-  def< bool >( d, names::regular_spike_arrival, regular_spike_arrival_ );
   def< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_ );
   def< double >( d, names::t_ref, t_ref_ );
   def< double >( d, names::tau_m, tau_m_ );
@@ -165,7 +163,6 @@ eprop_iaf_adapt::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< double >( d, names::beta, beta_, node );
   updateValueParam< double >( d, names::gamma, gamma_, node );
   updateValueParam< double >( d, names::I_e, I_e_, node );
-  updateValueParam< bool >( d, names::regular_spike_arrival, regular_spike_arrival_, node );
   updateValueParam< std::string >( d, names::surrogate_gradient_function, surrogate_gradient_function_, node );
   updateValueParam< double >( d, names::t_ref, t_ref_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
@@ -308,7 +305,6 @@ eprop_iaf_adapt::pre_run_hook()
 
   V_.P_v_m_ = std::exp( -dt / P_.tau_m_ );
   V_.P_i_in_ = P_.tau_m_ / P_.C_m_ * ( 1.0 - V_.P_v_m_ );
-  V_.P_z_in_ = P_.regular_spike_arrival_ ? 1.0 : 1.0 - V_.P_v_m_;
   V_.P_adapt_ = std::exp( -dt / P_.adapt_tau_ );
 }
 
@@ -342,8 +338,7 @@ eprop_iaf_adapt::update( Time const& origin, const long from, const long to )
 
     S_.z_in_ = B_.spikes_.get_value( lag );
 
-    S_.v_m_ = V_.P_i_in_ * S_.i_in_ + V_.P_z_in_ * S_.z_in_ + V_.P_v_m_ * S_.v_m_;
-    S_.v_m_ -= P_.V_th_ * S_.z_;
+    S_.v_m_ = V_.P_i_in_ * S_.i_in_ + S_.z_in_ + V_.P_v_m_ * S_.v_m_;
     S_.v_m_ = std::max( S_.v_m_, P_.V_min_ );
 
     S_.adapt_ = V_.P_adapt_ * S_.adapt_ + S_.z_;
@@ -360,6 +355,7 @@ eprop_iaf_adapt::update( Time const& origin, const long from, const long to )
       kernel().event_delivery_manager.send( *this, se, lag );
 
       S_.z_ = 1.0;
+      S_.v_m_ -= P_.V_th_ * S_.z_;
       S_.r_ = V_.RefractoryCounts_;
     }
 
@@ -454,7 +450,7 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
     L = eprop_hist_it->learning_signal_;
     firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
-    z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
+    z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = V_.P_adapt_ * epsilon + e;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -453,7 +453,7 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
     z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = V_.P_adapt_ * epsilon + e;
-    e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
+    e_bar = P_.kappa_ * e_bar + e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;
 
     if ( optimize_each_step )

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -198,10 +198,6 @@ Parameter                   Unit    Math equivalent         Default          Des
 ``C_m``                     pF      :math:`C_\text{m}`                 250.0 Capacitance of the membrane
 ``E_L``                     mV      :math:`E_\text{L}`                 -70.0 Leak / resting membrane potential
 ``I_e``                     pA      :math:`I_\text{e}`                   0.0 Constant external input current
-``regular_spike_arrival``   Boolean                                 ``True`` If ``True``, the input spikes
-                                                                             arrive at the end of the time step,
-                                                                             if ``False`` at the beginning
-                                                                             (determines PSC scale)
 ``t_ref``                   ms      :math:`t_\text{ref}`                 2.0 Duration of the refractory period
 ``tau_m``                   ms      :math:`\tau_\text{m}`               10.0 Time constant of the membrane
 ``V_min``                   mV      :math:`v_\text{min}`    negative maximum Absolute lower bound of the
@@ -414,9 +410,6 @@ private:
     //! Constant external input current (pA).
     double I_e_;
 
-    //! If True, the input spikes arrive at the beginning of the time step, if False at the end (determines PSC scale).
-    bool regular_spike_arrival_;
-
     //! Surrogate gradient / pseudo-derivative function of the membrane voltage ["piecewise_linear", "exponential",
     //! "fast_sigmoid_derivative", "arctan"]
     std::string surrogate_gradient_function_;
@@ -516,10 +509,6 @@ private:
   {
     //! Propagator matrix entry for evolving the membrane voltage (mathematical symbol "alpha" in user documentation).
     double P_v_m_;
-
-    //! Propagator matrix entry for evolving the incoming spike state variables (mathematical symbol "zeta" in user
-    //! documentation).
-    double P_z_in_;
 
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -445,7 +445,7 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
 
     z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * z_bar;
-    e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
+    e_bar = P_.kappa_ * e_bar + e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;
 
     if ( optimize_each_step )

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -486,7 +486,7 @@ eprop_iaf_psc_delta_adapt::compute_gradient( const long t_spike,
     z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = V_.P_adapt_ * epsilon + e;
-    e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
+    e_bar = P_.kappa_ * e_bar + e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;
 
     if ( optimize_each_step )

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -163,10 +163,6 @@ Parameter                 Unit    Math equivalent       Default            Descr
 ``C_m``                   pF      :math:`C_\text{m}`                 250.0 Capacitance of the membrane
 ``E_L``                   mV      :math:`E_\text{L}`                   0.0 Leak / resting membrane potential
 ``I_e``                   pA      :math:`I_\text{e}`                   0.0 Constant external input current
-``regular_spike_arrival`` Boolean                                 ``True`` If ``True``, the input spikes arrive
-                                                                           at the end of the time step, if
-                                                                           ``False`` at the beginning
-                                                                           (determines PSC scale)
 ``tau_m``                 ms      :math:`\tau_\text{m}`               10.0 Time constant of the membrane
 ``V_min``                 mV      :math:`v_\text{min}`  negative maximum   Absolute lower bound of the membrane
                                                         value              voltage
@@ -342,9 +338,6 @@ private:
     //! Constant external input current (pA).
     double I_e_;
 
-    //! If True, the input spikes arrive at the beginning of the time step, if False at the end (determines PSC scale).
-    bool regular_spike_arrival_;
-
     //! Time constant of the membrane (ms).
     double tau_m_;
 
@@ -422,10 +415,6 @@ private:
   {
     //! Propagator matrix entry for evolving the membrane voltage (mathematical symbol "kappa" in user documentation).
     double P_v_m_;
-
-    //! Propagator matrix entry for evolving the incoming spike state variables (mathematical symbol "zeta" in user
-    //! documentation).
-    double P_z_in_;
 
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
@@ -197,7 +197,6 @@ params_nrn_out = {
     "E_L": 0.0,  # mV, leak / resting membrane potential
     "eprop_isi_trace_cutoff": 100,  # cutoff of integration of eprop trace between spikes
     "I_e": 0.0,  # pA, external current input
-    "regular_spike_arrival": False,  # If True, input spikes arrive at end of time step, if False at beginning
     "tau_m": 20.0,  # ms, membrane time constant
     "V_m": 0.0,  # mV, initial value of the membrane voltage
 }
@@ -213,7 +212,6 @@ params_nrn_reg = {
     "I_e": 0.0,
     "kappa": 0.97,  # low-pass filter of the eligibility trace
     "kappa_reg": 0.97,  # low-pass filter of the firing rate for regularization
-    "regular_spike_arrival": True,
     "surrogate_gradient_function": "piecewise_linear",  # surrogate gradient / pseudo-derivative function
     "t_ref": 5.0,  # ms, duration of refractory period
     "tau_m": 20.0,
@@ -234,7 +232,6 @@ params_nrn_ad = {
     "I_e": 0.0,
     "kappa": 0.97,
     "kappa_reg": 0.97,
-    "regular_spike_arrival": True,
     "surrogate_gradient_function": "piecewise_linear",
     "t_ref": 5.0,
     "tau_m": 20.0,

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
@@ -210,8 +210,8 @@ params_nrn_reg = {
     "f_target": 10.0,  # spikes/s, target firing rate for firing rate regularization
     "gamma": 0.5,  # height scaling of the pseudo-derivative
     "I_e": 0.0,
-    "kappa": 0.97,  # low-pass filter of the eligibility trace
-    "kappa_reg": 0.97,  # low-pass filter of the firing rate for regularization
+    "kappa": 0.95,  # low-pass filter of the eligibility trace
+    "kappa_reg": 0.95,  # low-pass filter of the firing rate for regularization
     "surrogate_gradient_function": "piecewise_linear",  # surrogate gradient / pseudo-derivative function
     "t_ref": 5.0,  # ms, duration of refractory period
     "tau_m": 20.0,
@@ -230,8 +230,8 @@ params_nrn_ad = {
     "f_target": 10.0,
     "gamma": 0.5,
     "I_e": 0.0,
-    "kappa": 0.97,
-    "kappa_reg": 0.97,
+    "kappa": 0.95,
+    "kappa_reg": 0.95,
     "surrogate_gradient_function": "piecewise_linear",
     "t_ref": 5.0,
     "tau_m": 20.0,

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -189,7 +189,6 @@ params_nrn_out = {
     "E_L": 0.0,  # mV, leak / resting membrane potential
     "eprop_isi_trace_cutoff": 100,  # cutoff of integration of eprop trace between spikes
     "I_e": 0.0,  # pA, external current input
-    "regular_spike_arrival": False,  # If True, input spikes arrive at end of time step, if False at beginning
     "tau_m": 100.0,  # ms, membrane time constant
     "V_m": 0.0,  # mV, initial value of the membrane voltage
 }
@@ -205,7 +204,6 @@ params_nrn_rec = {
     "I_e": 0.0,
     "kappa": 0.99,  # low-pass filter of the eligibility trace
     "kappa_reg": 0.99,  # low-pass filter of the firing rate for regularization
-    "regular_spike_arrival": True,
     "surrogate_gradient_function": "piecewise_linear",  # surrogate gradient / pseudo-derivative function
     "t_ref": 0.0,  # ms, duration of refractory period
     "tau_m": 30.0,

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -179,7 +179,6 @@ params_nrn_out = {
     "E_L": 0.0,  # mV, leak / resting membrane potential
     "eprop_isi_trace_cutoff": 100,  # cutoff of integration of eprop trace between spikes
     "I_e": 0.0,  # pA, external current input
-    "regular_spike_arrival": False,  # If True, input spikes arrive at end of time step, if False at beginning
     "tau_m": 30.0,  # ms, membrane time constant
     "V_m": 0.0,  # mV, initial value of the membrane voltage
 }
@@ -195,7 +194,6 @@ params_nrn_rec = {
     "I_e": 0.0,
     "kappa": 0.97,  # low-pass filter of the eligibility trace
     "kappa_reg": 0.97,  # low-pass filter of the firing rate for regularization
-    "regular_spike_arrival": False,
     "surrogate_gradient_function": "piecewise_linear",  # surrogate gradient / pseudo-derivative function
     "t_ref": 0.0,  # ms, duration of refractory period
     "tau_m": 30.0,
@@ -204,7 +202,6 @@ params_nrn_rec = {
 }
 
 if model_nrn_rec in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
-    del params_nrn_rec["regular_spike_arrival"]
     params_nrn_rec["V_reset"] = -0.5  # mV, reset membrane voltage
     params_nrn_rec["c_reg"] = 2.0 / duration["sequence"]
     params_nrn_rec["V_th"] = 0.5

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -201,9 +201,11 @@ params_nrn_rec = {
     "V_th": 0.03,  # mV, spike threshold membrane voltage
 }
 
+scale_factor = 1.0 - params_nrn_rec["kappa"]  # factor for rescaling due to removal of irregular spike arrival
+
 if model_nrn_rec in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
     params_nrn_rec["V_reset"] = -0.5  # mV, reset membrane voltage
-    params_nrn_rec["c_reg"] = 2.0 / duration["sequence"]
+    params_nrn_rec["c_reg"] = 2.0 / duration["sequence"] / scale_factor**2
     params_nrn_rec["V_th"] = 0.5
 
 ####################
@@ -294,14 +296,21 @@ dtype_weights = np.float32  # data type of weights - for reproducing TF results 
 weights_in_rec = np.array(np.random.randn(n_in, n_rec).T / np.sqrt(n_in), dtype=dtype_weights)
 weights_rec_rec = np.array(np.random.randn(n_rec, n_rec).T / np.sqrt(n_rec), dtype=dtype_weights)
 np.fill_diagonal(weights_rec_rec, 0.0)  # since no autapses set corresponding weights to zero
-weights_rec_out = np.array(np.random.randn(n_rec, n_out).T / np.sqrt(n_rec), dtype=dtype_weights)
+weights_rec_out = np.array(np.random.randn(n_rec, n_out).T / np.sqrt(n_rec), dtype=dtype_weights) * scale_factor
 weights_out_rec = np.array(np.random.randn(n_rec, n_out) / np.sqrt(n_rec), dtype=dtype_weights)
+
+if model_nrn_rec == "eprop_iaf":
+    weights_in_rec *= scale_factor
+    weights_rec_rec *= scale_factor
+    weights_out_rec *= scale_factor
+elif model_nrn_rec in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
+    weights_out_rec /= scale_factor
 
 params_common_syn_eprop = {
     "optimizer": {
         "type": "gradient_descent",  # algorithm to optimize the weights
         "batch_size": 1,
-        "eta": 1e-4,  # learning rate
+        "eta": 1e-4 * scale_factor**2,  # learning rate
         "optimize_each_step": False,  # call optimizer every time step (True) or once per spike (False); both
         # yield same results for gradient descent, False offers speed-up
         "Wmin": -100.0,  # pA, minimal limit of the synaptic weights

--- a/testsuite/pytests/test_eprop_plasticity.py
+++ b/testsuite/pytests/test_eprop_plasticity.py
@@ -180,7 +180,6 @@ def test_eprop_regression(neuron_model, optimizer, loss_nest_reference):
         "E_L": 0.0,
         "eprop_isi_trace_cutoff": 100,
         "I_e": 0.0,
-        "regular_spike_arrival": False,
         "tau_m": 30.0,
         "V_m": 0.0,
     }
@@ -196,7 +195,6 @@ def test_eprop_regression(neuron_model, optimizer, loss_nest_reference):
         "I_e": 0.0,
         "kappa": 0.97,
         "kappa_reg": 0.97,
-        "regular_spike_arrival": False,
         "surrogate_gradient_function": "piecewise_linear",
         "t_ref": 0.0,
         "tau_m": 30.0,
@@ -205,7 +203,6 @@ def test_eprop_regression(neuron_model, optimizer, loss_nest_reference):
     }
 
     if neuron_model in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
-        del params_nrn_rec["regular_spike_arrival"]
         params_nrn_rec["V_reset"] = -0.5
         params_nrn_rec["c_reg"] = 2.0 / duration["sequence"]
         params_nrn_rec["V_th"] = 0.5
@@ -510,7 +507,6 @@ def test_eprop_surrogate_gradients(surrogate_gradient_type, surrogate_gradient_r
         "E_L": 0.0,
         "gamma": 0.5,
         "I_e": 0.0,
-        "regular_spike_arrival": False,
         "surrogate_gradient_function": surrogate_gradient_type,
         "t_ref": 3.0,
         "V_m": 0.0,

--- a/testsuite/pytests/test_eprop_plasticity.py
+++ b/testsuite/pytests/test_eprop_plasticity.py
@@ -71,44 +71,44 @@ def test_unsupported_model_raises(target_model):
             "eprop_iaf",
             "adam",
             [
-                0.13126137747586,
-                0.09395562983704,
-                0.00734052541014,
-                0.02909589949313,
-                0.00279041902009,
+                0.11299135657185,
+                0.24214707468622,
+                0.22801961532915,
+                0.18990506421410,
+                0.17807439012893,
             ],
         ),
         (
             "eprop_iaf_adapt",
             "gradient_descent",
             [
-                0.04298221363883,
-                0.03100545785399,
-                0.00930311104052,
-                0.00455478436740,
-                0.00017408818078,
+                0.02242584487453,
+                0.01916753791522,
+                0.00571493935652,
+                0.00037875376195,
+                0.00037823157578,
             ],
         ),
         (
             "eprop_iaf_psc_delta",
             "gradient_descent",
             [
-                0.32286231964124,
-                0.61322219696014,
-                0.63745062813969,
-                0.63844466107304,
-                0.58671835471489,
+                0.27039631749159,
+                0.51390204375229,
+                0.53473859833866,
+                0.53140089764207,
+                0.46251560097325,
             ],
         ),
         (
             "eprop_iaf_psc_delta_adapt",
             "gradient_descent",
             [
-                0.19603671513741,
-                0.33370485743782,
-                0.35727428693343,
-                0.31206408953001,
-                0.31411885659561,
+                0.16416646182675,
+                0.27952159282830,
+                0.28717519804974,
+                0.27112053231265,
+                0.28730274348102,
             ],
         ),
     ],
@@ -202,9 +202,11 @@ def test_eprop_regression(neuron_model, optimizer, loss_nest_reference):
         "V_th": 0.03,
     }
 
+    scale_factor = 1.0 - params_nrn_rec["kappa"]
+
     if neuron_model in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
         params_nrn_rec["V_reset"] = -0.5
-        params_nrn_rec["c_reg"] = 2.0 / duration["sequence"]
+        params_nrn_rec["c_reg"] = 2.0 / duration["sequence"] / scale_factor**2
         params_nrn_rec["V_th"] = 0.5
     elif neuron_model == "eprop_iaf_adapt":
         params_nrn_rec["adapt_beta"] = 0.0174
@@ -265,14 +267,21 @@ def test_eprop_regression(neuron_model, optimizer, loss_nest_reference):
     weights_in_rec = np.array(np.random.randn(n_in, n_rec).T / np.sqrt(n_in), dtype=dtype_weights)
     weights_rec_rec = np.array(np.random.randn(n_rec, n_rec).T / np.sqrt(n_rec), dtype=dtype_weights)
     np.fill_diagonal(weights_rec_rec, 0.0)
-    weights_rec_out = np.array(np.random.randn(n_rec, n_out).T / np.sqrt(n_rec), dtype=dtype_weights)
+    weights_rec_out = np.array(np.random.randn(n_rec, n_out).T / np.sqrt(n_rec), dtype=dtype_weights) * scale_factor
     weights_out_rec = np.array(np.random.randn(n_rec, n_out) / np.sqrt(n_rec), dtype=dtype_weights)
+
+    if neuron_model in ["eprop_iaf", "eprop_iaf_adapt"]:
+        weights_in_rec *= scale_factor
+        weights_rec_rec *= scale_factor
+        weights_out_rec *= scale_factor
+    elif neuron_model in ["eprop_iaf_psc_delta", "eprop_iaf_psc_delta_adapt"]:
+        weights_out_rec /= scale_factor
 
     params_common_syn_eprop = {
         "optimizer": {
             "type": optimizer,
             "batch_size": 1,
-            "eta": 1e-4,
+            "eta": 1e-4 * scale_factor**2,
             "optimize_each_step": True,
             "Wmin": -100.0,
             "Wmax": 100.0,
@@ -436,41 +445,41 @@ def test_unsupported_surrogate_gradient():
         (
             "piecewise_linear",
             [
-                0.06135126216450,
-                0.05456129183053,
-                0.04841747260500,
-                0.04285831508010,
-                0.03782818133881,
+                0.00000000000000,
+                0.06326028627150,
+                0.05628864827448,
+                0.04998044934977,
+                0.04427255492229,
             ],
         ),
         (
             "exponential",
             [
-                0.20795269433458,
-                0.20514779735629,
-                0.20264243938260,
-                0.20040187562686,
-                0.19839588646645,
+                0.00000000000000,
+                0.20874818539303,
+                0.20585774973044,
+                0.20327688132449,
+                0.20096951065442,
             ],
         ),
         (
             "fast_sigmoid_derivative",
             [
-                0.14187432621036,
-                0.13984381221999,
-                0.13804386008020,
-                0.13644497667035,
-                0.13502206566839,
+                0.00000000000000,
+                0.14245317962074,
+                0.14035621717075,
+                0.13849845457159,
+                0.13684908496324,
             ],
         ),
         (
             "arctan",
             [
-                0.01851467830587,
-                0.01801794405092,
-                0.01758480869073,
-                0.01720567699047,
-                0.01687268127553,
+                0.00000000000000,
+                0.01865787406582,
+                0.01814248109253,
+                0.01769356640047,
+                0.01730100362413,
             ],
         ),
     ],


### PR DESCRIPTION
This PR removes the `regular_spike_arrival` flag and the corresponding mechanism, which was initially in place to reproduce the behavior of the original model. Since `P_z_in=1`  that variable is no longer needed and is removed. To match the *regular spike arrival* at the end of the time step (the commit message erroneously says at the *beginning* of the time step), the spike threshold crossing reset is moved to the current time step $t$, resulting in the following timing in the membrane potential update equation:
```math
 v = v^{t-1} + 1\cdot z_\mathrm{in}^t - v_\mathrm{th}z^t\,,
```
instead of the previous
```math
 v = v^{t-1} + 1\cdot z_\mathrm{in}^t - v_\mathrm{th}z^{t-1}\,.
```
To use the new propagator in the sine waves task requires scaling the spike threshold with the old default propagator $v_\mathrm{th, new} = v_\mathrm{th, old} / (1-\mathrm{exp}(\mathrm{d}t / \tau_\mathrm{m}))$. To make the sine waves task with the new propagator consistent with the evidence accumulation task and since the convergence benefits from it, the membrane time constants in the system are decreased from 30 ms to 20 ms, leading to a new threshold potential equal to the one in the evidence accumulation task  $v_\mathrm{th, new} = 0.03 / (1-\mathrm{exp}(\mathrm{d}t / 20))=0.6$

The convergence on the sine waves task improves with this change:
![image](https://github.com/JesusEV/nest-simulator/assets/40828647/4ebddd13-8cce-4781-a5a2-c946d57d642b)

