### PR TITLE
Clarify eprop iaf psc delta purpose

### DIFF
--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -322,6 +322,13 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+protected:
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   void compute_gradient( const long t_spike,
     const long t_spike_previous,
     double& z_previous_buffer,
@@ -332,18 +339,10 @@ public:
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
-
-  //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the surrogate gradient.
   double ( eprop_iaf::*compute_surrogate_gradient )( double, double, double, double, double, double );
 

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -338,6 +338,12 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   void compute_gradient( const long t_spike,
     const long t_spike_previous,
     double& z_previous_buffer,
@@ -348,18 +354,11 @@ public:
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
 
-  //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the surrogate gradient.
   double ( eprop_iaf_adapt::*compute_surrogate_gradient )( double, double, double, double, double, double );
 

--- a/models/eprop_iaf_adapt_bsshslm_2020.h
+++ b/models/eprop_iaf_adapt_bsshslm_2020.h
@@ -311,21 +311,21 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   double compute_gradient( std::vector< long >& presyn_isis,
     const long t_previous_update,
     const long t_previous_trigger_spike,
     const double kappa,
     const bool average_gradient ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the surrogate gradient.
   double (
     eprop_iaf_adapt_bsshslm_2020::*compute_surrogate_gradient )( double, double, double, double, double, double );

--- a/models/eprop_iaf_bsshslm_2020.h
+++ b/models/eprop_iaf_bsshslm_2020.h
@@ -296,21 +296,21 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   double compute_gradient( std::vector< long >& presyn_isis,
     const long t_previous_update,
     const long t_previous_trigger_spike,
     const double kappa,
     const bool average_gradient ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the surrogate gradient.
   double ( eprop_iaf_bsshslm_2020::*compute_surrogate_gradient )( double, double, double, double, double, double );
 

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -297,6 +297,7 @@ nest::eprop_iaf_psc_delta::pre_run_hook()
   V_.P33_ = std::exp( -h / P_.tau_m_ );
   V_.P30_ = 1 / P_.c_m_ * ( 1 - V_.P33_ ) * P_.tau_m_;
 
+  V_.P_z_in_ = 1.0;
 
   // t_ref_ specifies the length of the absolute refractory period as
   // a double in ms. The grid based iaf_psp_delta can only handle refractory
@@ -318,8 +319,6 @@ nest::eprop_iaf_psc_delta::pre_run_hook()
   V_.RefractoryCounts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   // since t_ref_ >= 0, this can only fail in error
   assert( V_.RefractoryCounts_ >= 0 );
-
-  V_.P_z_in_ = 1.0;
 }
 
 long
@@ -391,9 +390,6 @@ nest::eprop_iaf_psc_delta::update( Time const& origin, const long from, const lo
     {
       S_.r_ = V_.RefractoryCounts_;
       S_.y3_ = P_.V_reset_;
-
-      // EX: must compute spike time
-      // set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
 
       SpikeEvent se;
       kernel().event_delivery_manager.send( *this, se, lag );

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -53,9 +53,9 @@ Description
 * a hard threshold,
 * a fixed refractory period,
 * Dirac delta (:math:`\delta`)-shaped synaptic input currents.
-* support for eligibility propagation (e-prop).
 
-It is the standard ``iaf_psc_delta`` model endowed with e-prop plasticity.
+
+The `eprop_iaf_psc_delta` is the standard ``iaf_psc_delta`` model endowed with e-prop plasticity.
 
 Membrane potential evolution, spike emission, and refractoriness
 ................................................................

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -255,6 +255,13 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   void compute_gradient( const long t_spike,
     const long t_spike_previous,
     double& z_previous_buffer,
@@ -267,18 +274,11 @@ public:
 
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-
-  //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
-
-private:
-  void init_buffers_() override;
-  void pre_run_hook() override;
-
-  void update( Time const&, const long, const long ) override;
 
   //! Compute the surrogate gradient.
   double ( eprop_iaf_psc_delta::*compute_surrogate_gradient )( double, double, double, double, double, double );
+
 
   // The next two classes need to be friends to access the State_ class/member
   friend class RecordablesMap< eprop_iaf_psc_delta >;

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -35,72 +35,122 @@
 
 namespace nest
 {
-
+// Disable clang-formatting for documentation due to over-wide table.
+// clang-format off
 /* BeginUserDocs: neuron, e-prop plasticity, integrate-and-fire, current-based
 
 Short description
 +++++++++++++++++
 
-Current-based leaky integrate-and-fire neuron model with delta-shaped
-postsynaptic currents for e-prop plasticity
+Leaky integrate-and-fire model with delta-shaped input currents
+for e-prop plasticity
 
 Description
 +++++++++++
 
-``eprop_iaf_psc_delta`` is an implementation of a leaky integrate-and-fire model
-where the potential jumps on each spike arrival used for eligibility propagation
-(e-prop) plasticity.
+``iaf_psc_delta`` is a leaky integrate-and-fire neuron model with
+
+* a hard threshold,
+* a fixed refractory period,
+* Dirac delta (:math:`\delta`)-shaped synaptic input currents.
+* support for eligibility propagation (e-prop).
 
 It is the standard ``iaf_psc_delta`` model endowed with e-prop plasticity.
 
-The threshold crossing is followed by an absolute refractory period
-during which the membrane potential is clamped to the resting potential.
+Membrane potential evolution, spike emission, and refractoriness
+................................................................
 
-Spikes arriving while the neuron is refractory, are discarded by
-default. If the property ``refractory_input`` is set to true, such
-spikes are added to the membrane potential at the end of the
-refractory period, dampened according to the interval between
-arrival and end of refractoriness.
+The membrane potential evolves according to
 
-The linear subthreshold dynamics is integrated by the Exact
-Integration scheme [1]_. The neuron dynamics is solved on the time
-grid given by the computation step size. Incoming as well as emitted
-spikes are forced to that grid.
+.. math::
 
-An additional state variable and the corresponding differential
-equation represents a piecewise constant external current.
+   \frac{dV_\text{m}}{dt} = -\frac{V_{\text{m}} - E_\text{L}}{\tau_{\text{m}}} + \dot{\Delta}_{\text{syn}} + \frac{I_{\text{syn}} + I_\text{e}}{C_{\text{m}}}
 
-The general framework for the consistent formulation of systems with
-neuron like dynamics interacting by point events is described in
-[1]_.  A flow chart can be found in [2]_.
+where the derivative of change in voltage due to synaptic input :math:`\dot{\Delta}_{\text{syn}}(t)` is discussed below and :math:`I_\text{e}` is
+a constant input current set as a model parameter.
 
-Critical tests for the formulation of the neuron model are the
-comparisons of simulation results for different computation step
-sizes. sli/testsuite/nest contains a number of such tests.
+A spike is emitted at time step :math:`t^*=t_{k+1}` if
 
-The iaf_psc_delta is the standard model used to check the consistency
-of the nest simulation kernel because it is at the same time complex
-enough to exhibit non-trivial dynamics and simple enough compute
-relevant measures analytically.
+.. math::
+
+   V_\text{m}(t_k) < V_{th} \quad\text{and}\quad V_\text{m}(t_{k+1})\geq V_\text{th} \;.
+
+Subsequently,
+
+.. math::
+
+   V_\text{m}(t) = V_{\text{reset}} \quad\text{for}\quad t^* \leq t < t^* + t_{\text{ref}} \;,
+
+that is, the membrane potential is clamped to :math:`V_{\text{reset}}` during the refractory period.
+
+Synaptic input
+..............
+
+The change in membrane potential due to synaptic inputs can be formulated as:
+
+.. math::
+
+   \dot{\Delta}_{\text{syn}}(t) = \sum_{j} w_j \sum_k \delta(t-t_j^k-d_j) \;,
+
+where :math:`j` indexes either excitatory (:math:`w_j > 0`)
+or inhibitory (:math:`w_j < 0`) presynaptic neurons,
+:math:`k` indexes the spike times of neuron :math:`j`, :math:`d_j`
+is the delay from neuron :math:`j`, and :math:`\delta` is the Dirac delta distribution.
+This implies that the jump in voltage upon a single synaptic input spike is
+
+.. math::
+
+   \Delta_{\text{syn}} = w \;,
+
+where :math:`w` is the corresponding synaptic weight in mV.
+
+
+The change in voltage caused by the synaptic input can be interpreted as being caused
+by individual post-synaptic currents (PSCs) given by
+
+.. math::
+
+   i_{\text{syn}}(t) = C_{\text{m}} \cdot w \cdot \delta(t).
+
+As a consequence, the total charge :math:`q` transferred by a single PSC is
+
+.. math::
+
+   q = \int_0^{\infty}  i_{\text{syn, X}}(t) dt = C_{\text{m}} \cdot w \;.
+
+By default, :math:`V_\text{m}` is not bounded from below. To limit
+hyperpolarization to biophysically plausible values, set parameter
+:math:`V_{\text{min}}` as lower bound of :math:`V_\text{m}`.
+
+
+
+
+
+.. note::
+   Spikes arriving while the neuron is refractory, are discarded by
+   default. If the property ``refractory_input`` is set to True, such
+   spikes are added to the membrane potential at the end of the
+   refractory period, dampened according to the interval between
+   arrival and end of refractoriness.
 
 Parameters
 ++++++++++
 
 The following parameters can be set in the status dictionary.
 
-================= ======= ======================================================
- V_m              mV      Membrane potential
- E_L              mV      Resting membrane potential
- C_m              pF      Capacity of the membrane
- tau_m            ms      Membrane time constant
- t_ref            ms      Duration of refractory period
- V_th             mV      Spike threshold
- V_reset          mV      Reset potential of the membrane
- I_e              pA      Constant input current
- V_min            mV      Absolute lower value for the membrane potential
- refractory_input boolean If true, do not discard input during
-                          refractory period. Default: false
-================= ======= ======================================================
+==================== ================== =============================== ==================================================================================
+**Parameter**        **Default**        **Math equivalent**             **Description**
+==================== ================== =============================== ==================================================================================
+``E_L``              -70 mV             :math:`E_\text{L}`              Resting membrane potential
+``C_m``              250 pF             :math:`C_{\text{m}}`            Capacitance of the membrane
+``tau_m``            10 ms              :math:`\tau_{\text{m}}`         Membrane time constant
+``t_ref``            2 ms               :math:`t_{\text{ref}}`          Duration of refractory period
+``V_th``             -55 mV             :math:`V_{\text{th}}`           Spike threshold
+``V_reset``          -70 mV             :math:`V_{\text{reset}}`        Reset potential of the membrane
+``I_e``              0 pA               :math:`I_\text{e}`              Constant input current
+``V_min``            :math:`-\infty` mV :math:`V_{\text{min}}`          Absolute lower value for the membrane potential
+``refractory_input`` ``False``          None                            If set to True, spikes arriving during refractory period are integrated afterwards
+==================== ================== =============================== ==================================================================================
 
 =========================== ======= ======================= ================ ===================================
 **E-prop parameters**
@@ -215,25 +265,23 @@ public:
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
 
   //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
 
-protected:
-  void init_buffers_() override;
-
 private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   //! Compute the surrogate gradient.
   double ( eprop_iaf_psc_delta::*compute_surrogate_gradient )( double, double, double, double, double, double );
 
-  //! Map for storing a static set of recordables.
+  // The next two classes need to be friends to access the State_ class/member
   friend class RecordablesMap< eprop_iaf_psc_delta >;
-
-  //! Logger for universal data supporting the data logging request / reply mechanism. Populated with a recordables map.
   friend class UniversalDataLogger< eprop_iaf_psc_delta >;
 
   // ----------------------------------------------------------------
@@ -275,7 +323,6 @@ private:
     //! Prefactor of firing rate regularization.
     double c_reg_;
 
-
     //! Target firing rate of rate regularization (spikes/s).
     double f_target_;
 
@@ -292,8 +339,8 @@ private:
     //! Low-pass filter of the eligibility trace.
     double kappa_;
 
-    //!< Number of time steps integrated between two consecutive spikes is equal to the minimum between
-    //!< eprop_isi_trace_cutoff_ and the inter-spike distance.
+    //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
+    //! eprop_isi_trace_cutoff_ and the inter-spike distance.
     long eprop_isi_trace_cutoff_;
 
     Parameters_(); //!< Sets default parameter values
@@ -481,7 +528,6 @@ eprop_iaf_psc_delta::get_status( DictionaryDatum& d ) const
 {
   P_.get( d );
   S_.get( d, P_ );
-  // ArchivingNode::get_status( d );
   ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
 
@@ -497,7 +543,6 @@ eprop_iaf_psc_delta::set_status( const DictionaryDatum& d )
   // write them back to (P_, S_) before we are also sure that
   // the properties to be set in the parent class are internally
   // consistent.
-  // ArchivingNode::set_status( d );
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -294,6 +294,12 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   void compute_gradient( const long t_spike,
     const long t_spike_previous,
     double& z_previous_buffer,
@@ -304,18 +310,10 @@ public:
     const CommonSynapseProperties& cp,
     WeightOptimizer* optimizer ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
-
-  //! Get maximum number of time steps integrated between two consecutive spikes.
   long get_eprop_isi_trace_cutoff() override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the error signal based on the mean-squared error loss.
   void compute_error_signal_mean_squared_error( const long lag );
 

--- a/models/eprop_readout_bsshslm_2020.h
+++ b/models/eprop_readout_bsshslm_2020.h
@@ -284,21 +284,21 @@ public:
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 
+private:
+  void init_buffers_() override;
+  void pre_run_hook() override;
+
+  void update( Time const&, const long, const long ) override;
+
   double compute_gradient( std::vector< long >& presyn_isis,
     const long t_previous_update,
     const long t_previous_trigger_spike,
     const double kappa,
     const bool average_gradient ) override;
 
-  void pre_run_hook() override;
   long get_shift() const override;
   bool is_eprop_recurrent_node() const override;
-  void update( Time const&, const long, const long ) override;
 
-protected:
-  void init_buffers_() override;
-
-private:
   //! Compute the error signal based on the mean-squared error loss.
   void compute_error_signal_mean_squared_error( const long lag );
 

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -551,17 +551,17 @@ nest::Node::get_tau_syn_in( int )
 }
 
 void
-nest::Node::compute_gradient( const long t_spike,
-  const long t_spike_previous,
-  double& z_previous_buffer,
-  double& z_bar,
-  double& e_bar,
-  double& epsilon,
-  double& weight,
-  const CommonSynapseProperties& cp,
-  WeightOptimizer* optimizer )
+nest::Node::compute_gradient( const long,
+  const long,
+  double&,
+  double&,
+  double&,
+  double&,
+  double&,
+  const CommonSynapseProperties&,
+  WeightOptimizer* )
 {
-  throw KernelException( "The target node does not support compute_gradient()." );
+  throw IllegalConnection( "The target node does not support compute_gradient()." );
 }
 
 double

--- a/pynest/examples/eprop_plasticity/README.rst
+++ b/pynest/examples/eprop_plasticity/README.rst
@@ -14,6 +14,11 @@ of e-prop [3]_ and how to visualize the simulation recordings.
 The tutorials with names ending in `_bsshslm_2020` use this original e-prop model. In contrast, the tutorials
 without this suffix use an e-prop version with additional biological features described in [3]_.
 
+Users interested in endowing an existing model with e-prop plasticity, may compare the .cpp and .h files of the
+:doc:`iaf_psc_delta</models/iaf_psc_delta>` and :doc:`eprop_iaf_psc_delta</models/eprop_iaf_psc_delta>` model.
+Parameters to run the `eprop_iaf_psc_delta` model are provided in
+:doc:`eprop_supervised_regression_sine-waves.py <eprop_supervised_regression_sine-waves>`.
+
 References
 ----------
 

--- a/pynest/examples/eprop_plasticity/README.rst
+++ b/pynest/examples/eprop_plasticity/README.rst
@@ -11,7 +11,9 @@ supervised classification task to accumulate evidence [2]_. Here, you find tutor
 reproduce these two tasks as well as two more advanced regression tasks using the NEST implementation
 of e-prop [3]_ and how to visualize the simulation recordings.
 
-The tutorials with names ending in `_bsshslm_2020` use this original e-prop model. In contrast, the tutorials
+The tutorials with names ending in `_bsshslm_2020` use this original e-prop model. The suffix _bsshslm_2020
+follows the NEST convention to indicate in the model name the paper that introduced it by the first letter of
+the authors' last names and the publication year. In contrast, the tutorials
 without this suffix use an e-prop version with additional biological features described in [3]_.
 
 Users interested in endowing an existing model with e-prop plasticity, may compare the .cpp and .h files of the

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation.py
@@ -184,8 +184,6 @@ n_reg = 50  # number of regular neurons
 n_rec = n_ad + n_reg  # number of recurrent neurons
 n_out = 2  # number of readout neurons
 
-model_nrn_reg = "eprop_iaf"
-
 params_nrn_out = {
     "C_m": 1.0,  # pF, membrane capacitance - takes effect only if neurons get current input (here not the case)
     "E_L": 0.0,  # mV, leak / resting membrane potential
@@ -213,12 +211,6 @@ params_nrn_reg = {
     "V_th": 0.6,  # mV, spike threshold membrane voltage
     "kappa": 0.97,  # low-pass filter of the eligibility trace
 }
-
-if model_nrn_reg == "eprop_iaf_psc_delta":
-    del params_nrn_reg["regular_spike_arrival"]
-    params_nrn_reg["V_reset"] = -0.5  # mV, reset membrane voltage
-    params_nrn_reg["c_reg"] = 2.0 / duration["sequence"] * duration["learning_window"]
-    params_nrn_reg["V_th"] = 0.5
 
 params_nrn_ad = {
     "beta": 1.0,
@@ -253,7 +245,7 @@ params_nrn_ad["adapt_beta"] = 1.7 * (
 gen_spk_in = nest.Create("spike_generator", n_in)
 nrns_in = nest.Create("parrot_neuron", n_in)
 
-nrns_reg = nest.Create(model_nrn_reg, n_reg, params_nrn_reg)
+nrns_reg = nest.Create("eprop_iaf", n_reg, params_nrn_reg)
 nrns_ad = nest.Create("eprop_iaf_adapt", n_ad, params_nrn_ad)
 nrns_out = nest.Create("eprop_readout", n_out, params_nrn_out)
 gen_rate_target = nest.Create("step_rate_generator", n_out)

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""
-Tutorial on learning to accumulate evidence with e-prop
--------------------------------------------------------
+Tutorial on learning to accumulate evidence with e-prop (_bsshslm_2020)
+-----------------------------------------------------------------------
 
 Training a classification model using supervised e-prop plasticity to accumulate evidence.
 

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -185,8 +185,6 @@ n_out = 10  # number of readout neurons
 
 eta_training = 5e-3
 eta_testing = 0.0
-model_nrn_rec = "eprop_iaf"
-
 params_nrn_out = {
     "C_m": 1.0,  # pF, membrane capacitance - takes effect only if neurons get current input (here not the case)
     "E_L": 0.0,  # mV, leak / resting membrane potential
@@ -215,11 +213,6 @@ params_nrn_rec = {
     "kappa": 0.99,  # low-pass filter of the eligibility trace
 }
 
-if model_nrn_rec == "eprop_iaf_psc_delta":
-    del params_nrn_rec["regular_spike_arrival"]
-    params_nrn_rec["V_reset"] = -0.5  # mV, reset membrane voltage
-    params_nrn_rec["V_th"] = 0.5
-
 ####################
 
 # Intermediate parrot neurons required between input spike generators and recurrent neurons,
@@ -228,7 +221,7 @@ if model_nrn_rec == "eprop_iaf_psc_delta":
 gen_spk_in = nest.Create("spike_generator", n_in)
 nrns_in = nest.Create("parrot_neuron", n_in)
 
-nrns_rec = nest.Create(model_nrn_rec, n_rec, params_nrn_rec)
+nrns_rec = nest.Create("eprop_iaf", n_rec, params_nrn_rec)
 nrns_out = nest.Create("eprop_readout", n_out, params_nrn_out)
 gen_rate_target = nest.Create("step_rate_generator", n_out)
 gen_learning_window = nest.Create("step_rate_generator")

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""
-Tutorial on learning to generate handwritten text with e-prop
--------------------------------------------------------------
+Tutorial on learning to generate handwritten text with e-prop (_bsshslm_2020)
+-----------------------------------------------------------------------------
 
 Training a regression model using supervised e-prop plasticity to generate handwritten text
 

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""
-Tutorial on learning to generate a lemniscate with e-prop
--------------------------------------------------------------
+Tutorial on learning to generate a lemniscate with e-prop (_bsshslm_2020)
+-------------------------------------------------------------------------
 
 Training a regression model using supervised e-prop plasticity to generate a lemniscate
 

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""
-Tutorial on learning to generate sine waves with e-prop
--------------------------------------------------------
+Tutorial on learning to generate sine waves with e-prop (_bsshslm_2020)
+-----------------------------------------------------------------------
 
 Training a regression model using supervised e-prop plasticity to generate sine waves
 


### PR DESCRIPTION
This PR aims to

- clarify the purpose of the `eprop_iaf_psc_delta` neuron model as the `iaf_psc_delta` neuron model endowed with e-prop plasticity.
- reduce the differences between the two models.
- make `pre_run_hook`, `init_buffers`, and `update` private functions in all e-prop models as in the standard `iaf_psc_delta` .
- make e-prop related functions private.
- remove doxygen comment of `get_eprop_isi_trace_cutoff` since it is inherited from `node.h`.
- add `_bsshslm_2020` to the tutorials headers to make them easily distinguishable in the compiled documentation.
-  make the compute gradient definition consistent.