### PR TITLE
Implement early stopping

### DIFF
--- a/models/weight_optimizer.cpp
+++ b/models/weight_optimizer.cpp
@@ -77,7 +77,14 @@ WeightOptimizerCommonProperties::set_status( const DictionaryDatum& d )
   {
     throw BadProperty( "Learning rate eta ≥ 0 required." );
   }
-  eta_ = new_eta;
+
+  eta_temp_ = new_eta;
+
+  if ( first_set_status_call_ )
+  {
+    eta_ = new_eta;
+    first_set_status_call_ = false;
+  }
 
   double new_Wmin = Wmin_;
   double new_Wmax = Wmax_;
@@ -110,7 +117,7 @@ WeightOptimizer::set_status( const DictionaryDatum& d )
 }
 
 double
-WeightOptimizer::optimized_weight( const WeightOptimizerCommonProperties& cp,
+WeightOptimizer::optimized_weight( WeightOptimizerCommonProperties& cp,
   const size_t idx_current_update,
   const double gradient,
   double weight )
@@ -127,6 +134,7 @@ WeightOptimizer::optimized_weight( const WeightOptimizerCommonProperties& cp,
   {
     sum_gradients_ /= cp.batch_size_;
     weight = std::max( cp.Wmin_, std::min( optimize_( cp, weight, current_optimization_step ), cp.Wmax_ ) );
+    cp.eta_ = cp.eta_temp_;
     optimization_step_ = current_optimization_step;
   }
   return weight;

--- a/models/weight_optimizer.h
+++ b/models/weight_optimizer.h
@@ -207,14 +207,14 @@ public:
   //! Size of an optimization batch.
   size_t batch_size_;
 
-  //! Learning rate.
+  //! Learning rate common to all synapses.
   double eta_;
 
-  //! Temporary learning rate in case it is changed during an experiment.
-  double eta_temp_;
+  //! First learning rate that differs from the default.
+  double eta_first_;
 
-  //! First call of set_status needed for setting a new eta during an experiment.
-  bool first_set_status_call_ = true;
+  //! Number of changes to the learning rate.
+  long n_eta_change_;
 
   //! Minimal value for synaptic weight.
   double Wmin_;
@@ -272,6 +272,12 @@ protected:
 
   //! Current optimization step, whereby optimization happens every batch_size_ steps.
   size_t optimization_step_;
+
+  //! Learning rate private to the synapse.
+  double eta_;
+
+  //! Number of optimizations.
+  long n_optimize_;
 };
 
 /**

--- a/models/weight_optimizer.h
+++ b/models/weight_optimizer.h
@@ -210,6 +210,12 @@ public:
   //! Learning rate.
   double eta_;
 
+  //! Temporary learning rate in case it is changed during an experiment.
+  double eta_temp_;
+
+  //! First call of set_status needed for setting a new eta during an experiment.
+  bool first_set_status_call_ = true;
+
   //! Minimal value for synaptic weight.
   double Wmin_;
 
@@ -252,7 +258,7 @@ public:
   virtual void set_status( const DictionaryDatum& d );
 
   //! Return optimized weight based on current weight.
-  double optimized_weight( const WeightOptimizerCommonProperties& cp,
+  double optimized_weight( WeightOptimizerCommonProperties& cp,
     const size_t idx_current_update,
     const double gradient,
     double weight );

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
@@ -316,13 +316,11 @@ params_wr = {
 
 params_sr_in = {
     "start": duration["offset_gen"],
-    "stop": duration["total_offset"] + duration["task"],
     "label": "spike_recorder_in",
 }
 
 params_sr_reg = {
     "start": duration["offset_gen"],
-    "stop": duration["total_offset"] + duration["task"],
     "label": "spike_recorder_reg",
 }
 
@@ -635,7 +633,7 @@ def evaluate(n_iter_start, n_iter_interval, phase_label):
     errors = 1.0 - accuracy
 
     results_dict["iteration"].extend(range(n_iter_start, n_iter_start + n_iter_interval))
-    results_dict["error"].extend(error_val)
+    results_dict["error"].extend(errors)
     results_dict["loss"].extend(loss)
     results_dict["label"].extend([phase_label] * len(loss))
 
@@ -813,9 +811,9 @@ def plot_spikes(ax, events, ylabel, xlims):
 for title, xlims in zip(
     ["Dynamic variables before training", "Dynamic variables after training"],
     [
-    (0, steps["sequence"]),
-    ((n_iter_sim - 1) * batch_size * steps["sequence"], n_iter_sim * batch_size * steps["sequence"]),
-],
+        (0, steps["sequence"]),
+        ((n_iter_sim - 1) * batch_size * steps["sequence"], n_iter_sim * batch_size * steps["sequence"]),
+    ],
 ):
     fig, axs = plt.subplots(14, 1, sharex=True, figsize=(8, 14), gridspec_kw={"hspace": 0.4, "left": 0.2})
     fig.suptitle(title)


### PR DESCRIPTION
This PR replaces PR #2  and implements the early-stopping algorithm as described in [the corresponding evidence accumulation task implemented in TensorFlow](https://github.com/IGITUGraz/eligibility_propagation/blob/master/Figure_3_and_S7_e_prop_tutorials/tutorial_evidence_accumulation_with_alif.py). The only difference is that here the early-stopping criterion is evaluated after each validation step ( e.g., every ten iterations) and not after every iteration as in the TensorFlow implementation. Since the early-stopping is assessed in the first instance with the newest validation value, evaluating the early-stopping for ten iterations with the same validation result as in the TensorFlow implementation seems wasteful.

Currently, the NEST losses match the TF losses for the iterations where there has not been a weight update yet; those are the first two iterations.

```
NEST:
0.74115255000619 validation
0.75886758496570 training
0.64575804540432 training
0.65036521347625 training
0.73954336799350 training
0.64857381599914 training
0.63293547882357 test
0.74871743652812 test
0.63259857933630 test
0.65171656508917 test
```

```
TF:
0.74115252494812 validation
0.75886762142181 training
0.64488172531128 training
0.63414341211319 training
0.74553966522217 training
0.65522724390030 training
0.62222802639008 test
0.75369793176651 test
0.63924121856689 test
0.65074861049652 test
```
To see if these deviations are due to an extra spike that results from numerical differences between TensorFlow and NEST, in the following experiment, a recurrent neuron (index 82) was forced to emit an extra spike at t = 4000, which is in the second iteration. This perturbation causes a deviation in the loss's 11th decimal digit.
```
NEST (perturbed):
0.74115255000619 validation
0.75886758494402 training
0.64732471934116 training
0.65337249687406 training
0.73455409141632 training
0.64412005064290 training
0.64022872139437 test
0.74554388366270 test
0.62969715145448 test
0.64486264066109 test
```
Therefore, probably the reason for the deviation between TF and NEST is that the gradients were not computed correctly.

- [x] investigate reason for deviation between TF and NEST