### PR TITLE
Fix cutoff limit handling

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -83,7 +83,7 @@ eprop_iaf::Parameters_::Parameters_()
   , V_th_( -55.0 - E_L_ )
   , kappa_( 0.97 )
   , kappa_reg_( 0.97 )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
+  , eprop_isi_trace_cutoff_( 1000.0 )
 {
 }
 

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -403,14 +403,10 @@ eprop_iaf::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
-    ? t_spike
-    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
+  const long t_compute_until = std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    assert( eprop_hist_it != eprop_history_.end() );
-
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -83,7 +83,7 @@ eprop_iaf::Parameters_::Parameters_()
   , V_th_( -55.0 - E_L_ )
   , kappa_( 0.97 )
   , kappa_reg_( 0.97 )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
+  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
 {
 }
 
@@ -130,7 +130,7 @@ eprop_iaf::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::V_th, V_th_ + E_L_ );
   def< double >( d, names::kappa, kappa_ );
   def< double >( d, names::kappa_reg, kappa_reg_ );
-  def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
+  def< double >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
 }
 
 double
@@ -161,7 +161,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
   updateValueParam< double >( d, names::kappa, kappa_, node );
   updateValueParam< double >( d, names::kappa_reg, kappa_reg_, node );
-  updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
+  updateValueParam< double >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
 
   if ( C_m_ <= 0 )
   {
@@ -203,7 +203,7 @@ eprop_iaf::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Firing rate low-pass filter for regularization kappa_reg from range [0, 1] required." );
   }
 
-  if ( eprop_isi_trace_cutoff_ < 0 )
+  if ( eprop_isi_trace_cutoff_ < 0.0 )
   {
     throw BadProperty( "Cutoff of integration of eprop trace between spikes eprop_isi_trace_cutoff ≥ 0 required." );
   }
@@ -264,6 +264,7 @@ eprop_iaf::pre_run_hook()
   B_.logger_.init(); // ensures initialization in case multimeter connected after Simulate
 
   V_.RefractoryCounts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
+  V_.eprop_isi_trace_cutoff_steps_ = Time( Time::ms( P_.eprop_isi_trace_cutoff_ ) ).get_steps();
 
   compute_surrogate_gradient_ = select_surrogate_gradient( P_.surrogate_gradient_function_ );
 
@@ -402,10 +403,14 @@ eprop_iaf::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
+    ? t_spike
+    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
+    assert( eprop_hist_it != eprop_history_.end() );
+
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;
@@ -435,13 +440,13 @@ eprop_iaf::compute_gradient( const long t_spike,
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t_compute_until, grad, weight );
   }
 
-  const long power = t_spike - ( t_spike_previous + P_.eprop_isi_trace_cutoff_ );
+  const long cutoff_to_spike_interval = t_spike - t_spike_previous - V_.eprop_isi_trace_cutoff_steps_;
 
-  if ( power > 0 )
+  if ( cutoff_to_spike_interval > 0 )
   {
-    z_bar *= std::pow( V_.P_v_m_, power );
-    e_bar *= std::pow( P_.kappa_, power );
-    e_bar_reg *= std::pow( P_.kappa_reg_, power );
+    z_bar *= std::pow( V_.P_v_m_, cutoff_to_spike_interval );
+    e_bar *= std::pow( P_.kappa_, cutoff_to_spike_interval );
+    e_bar_reg *= std::pow( P_.kappa_reg_, cutoff_to_spike_interval );
   }
 }
 

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -406,9 +406,8 @@ private:
     //! Low-pass filter of the firing rate for regularization.
     double kappa_reg_;
 
-    //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
-    //! eprop_isi_trace_cutoff_ and the inter-spike distance.
-    long eprop_isi_trace_cutoff_;
+    //! Time interval from the previous spike until the cutoff of e-prop update integration between two spikes (ms).
+    double eprop_isi_trace_cutoff_;
 
     //! Default constructor.
     Parameters_();
@@ -488,6 +487,9 @@ private:
 
     //! Total refractory steps.
     int RefractoryCounts_;
+
+    //! Time steps from the previous spike until the cutoff of e-prop update integration between two spikes.
+    long eprop_isi_trace_cutoff_steps_;
   };
 
   //! Get the current value of the membrane voltage.
@@ -532,7 +534,7 @@ private:
 inline long
 eprop_iaf::get_eprop_isi_trace_cutoff() const
 {
-  return P_.eprop_isi_trace_cutoff_;
+  return V_.eprop_isi_trace_cutoff_steps_;
 }
 
 inline size_t

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -442,14 +442,10 @@ eprop_iaf_adapt::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
-    ? t_spike
-    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
+  const long t_compute_until = std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    assert( eprop_hist_it != eprop_history_.end() );
-
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -87,7 +87,7 @@ eprop_iaf_adapt::Parameters_::Parameters_()
   , V_th_( -55.0 - E_L_ )
   , kappa_( 0.97 )
   , kappa_reg_( 0.97 )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
+  , eprop_isi_trace_cutoff_( 1000.0 )
 {
 }
 

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -427,9 +427,8 @@ private:
     //! Low-pass filter of the firing rate for regularization.
     double kappa_reg_;
 
-    //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
-    //! eprop_isi_trace_cutoff_ and the inter-spike distance.
-    long eprop_isi_trace_cutoff_;
+    //! Time interval from the previous spike until the cutoff of e-prop update integration between two spikes (ms).
+    double eprop_isi_trace_cutoff_;
 
     //! Default constructor.
     Parameters_();
@@ -518,6 +517,9 @@ private:
 
     //! Total refractory steps.
     int RefractoryCounts_;
+
+    //! Time steps from the previous spike until the cutoff of e-prop update integration between two spikes.
+    long eprop_isi_trace_cutoff_steps_;
   };
 
   //! Get the current value of the membrane voltage.
@@ -576,7 +578,7 @@ private:
 inline long
 eprop_iaf_adapt::get_eprop_isi_trace_cutoff() const
 {
-  return P_.eprop_isi_trace_cutoff_;
+  return V_.eprop_isi_trace_cutoff_steps_;
 }
 
 inline size_t

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -486,14 +486,10 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
-    ? t_spike
-    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
+  const long t_compute_until = std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    assert( eprop_hist_it != eprop_history_.end() );
-
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -88,7 +88,7 @@ nest::eprop_iaf_psc_delta::Parameters_::Parameters_()
   , surrogate_gradient_function_( "piecewise_linear" )
   , kappa_( 0.97 )
   , kappa_reg_( 0.97 )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
+  , eprop_isi_trace_cutoff_( 1000.0 )
 {
 }
 

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -346,9 +346,8 @@ private:
     //! Low-pass filter of the firing rate for regularization.
     double kappa_reg_;
 
-    //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
-    //! eprop_isi_trace_cutoff_ and the inter-spike distance.
-    long eprop_isi_trace_cutoff_;
+    //! Time interval from the previous spike until the cutoff of e-prop update integration between two spikes (ms).
+    double eprop_isi_trace_cutoff_;
 
     Parameters_(); //!< Sets default parameter values
 
@@ -432,6 +431,10 @@ private:
     double P_z_in_;
 
     int RefractoryCounts_;
+
+    //! Time steps from the previous spike until the cutoff of e-prop update integration between two spikes.
+    long eprop_isi_trace_cutoff_steps_;
+
   };
 
   // Access functions for UniversalDataLogger -------------------------------
@@ -478,7 +481,7 @@ private:
 inline long
 eprop_iaf_psc_delta::get_eprop_isi_trace_cutoff() const
 {
-  return P_.eprop_isi_trace_cutoff_;
+  return V_.eprop_isi_trace_cutoff_steps_;
 }
 
 inline size_t

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -75,7 +75,7 @@ eprop_readout::Parameters_::Parameters_()
   , regular_spike_arrival_( true )
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< long >::max() )
+  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
 {
 }
 
@@ -112,7 +112,7 @@ eprop_readout::Parameters_::get( DictionaryDatum& d ) const
   def< bool >( d, names::regular_spike_arrival, regular_spike_arrival_ );
   def< double >( d, names::tau_m, tau_m_ );
   def< double >( d, names::V_min, V_min_ + E_L_ );
-  def< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
+  def< double >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_ );
 }
 
 double
@@ -129,7 +129,7 @@ eprop_readout::Parameters_::set( const DictionaryDatum& d, Node* node )
   updateValueParam< double >( d, names::I_e, I_e_, node );
   updateValueParam< bool >( d, names::regular_spike_arrival, regular_spike_arrival_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
-  updateValueParam< long >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
+  updateValueParam< double >( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_, node );
 
   if ( C_m_ <= 0 )
   {
@@ -141,7 +141,7 @@ eprop_readout::Parameters_::set( const DictionaryDatum& d, Node* node )
     throw BadProperty( "Membrane time constant tau_m > 0 required." );
   }
 
-  if ( eprop_isi_trace_cutoff_ < 0 )
+  if ( eprop_isi_trace_cutoff_ < 0.0 )
   {
     throw BadProperty( "Cutoff of integration of eprop trace between spikes eprop_isi_trace_cutoff ≥ 0 required." );
   }
@@ -201,6 +201,8 @@ void
 eprop_readout::pre_run_hook()
 {
   B_.logger_.init(); // ensures initialization in case multimeter connected after Simulate
+
+  V_.eprop_isi_trace_cutoff_steps_ = Time( Time::ms( P_.eprop_isi_trace_cutoff_ ) ).get_steps();
 
   compute_error_signal = &eprop_readout::compute_error_signal_mean_squared_error;
 
@@ -349,10 +351,14 @@ eprop_readout::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = std::min( t_spike_previous + P_.eprop_isi_trace_cutoff_, t_spike );
+  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
+    ? t_spike
+    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
+    assert( eprop_hist_it != eprop_history_.end() );
+
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;
@@ -377,11 +383,11 @@ eprop_readout::compute_gradient( const long t_spike,
     weight = optimizer->optimized_weight( *ecp.optimizer_cp_, t_compute_until, grad, weight );
   }
 
-  const long power = t_spike - ( t_spike_previous + P_.eprop_isi_trace_cutoff_ );
+  const long cutoff_to_spike_interval = t_spike - t_spike_previous - V_.eprop_isi_trace_cutoff_steps_;
 
-  if ( power > 0 )
+  if ( cutoff_to_spike_interval > 0 )
   {
-    z_bar *= std::pow( V_.P_v_m_, power );
+    z_bar *= std::pow( V_.P_v_m_, cutoff_to_spike_interval );
   }
 }
 

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -75,7 +75,7 @@ eprop_readout::Parameters_::Parameters_()
   , regular_spike_arrival_( true )
   , tau_m_( 10.0 )
   , V_min_( -std::numeric_limits< double >::max() )
-  , eprop_isi_trace_cutoff_( std::numeric_limits< double >::max() )
+  , eprop_isi_trace_cutoff_( 1000.0 )
 {
 }
 

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -351,14 +351,10 @@ eprop_readout::compute_gradient( const long t_spike,
 
   auto eprop_hist_it = get_eprop_history( t_spike_previous - 1 );
 
-  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
-    ? t_spike
-    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
+  const long t_compute_until = std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
 
   for ( long t = t_spike_previous; t < t_compute_until; ++t, ++eprop_hist_it )
   {
-    assert( eprop_hist_it != eprop_history_.end() );
-
     z = z_previous_buffer;
     z_previous_buffer = z_current_buffer;
     z_current_buffer = 0.0;

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -348,9 +348,8 @@ private:
     //! Absolute lower bound of the membrane voltage relative to the leak membrane potential (mV).
     double V_min_;
 
-    //! Number of time steps integrated between two consecutive spikes is equal to the minimum between
-    //! eprop_isi_trace_cutoff_ and the inter-spike distance.
-    long eprop_isi_trace_cutoff_;
+    //! Time interval from the previous spike until the cutoff of e-prop update integration between two spikes (ms).
+    double eprop_isi_trace_cutoff_;
 
     //! Default constructor.
     Parameters_();
@@ -427,6 +426,9 @@ private:
 
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;
+
+    //! Time steps from the previous spike until the cutoff of e-prop update integration between two spikes.
+    long eprop_isi_trace_cutoff_steps_;
   };
 
   //! Minimal spike receptor type. Start with 1 to forbid port 0 and avoid accidental creation of connections with no
@@ -490,7 +492,7 @@ private:
 inline long
 eprop_readout::get_eprop_isi_trace_cutoff() const
 {
-  return P_.eprop_isi_trace_cutoff_;
+  return V_.eprop_isi_trace_cutoff_steps_;
 }
 
 inline size_t


### PR DESCRIPTION
This PR addresses comments https://github.com/nest/nest-simulator/pull/3207/files#r1742467860 and https://github.com/nest/nest-simulator/pull/3207/files#r1742458894 by:

- Preventing a potential overflow when adding to `eprop_isi_trace_cutoff`.
- Converting `eprop_isi_trace_cutoff` to a `double`, representing the cutoff in milliseconds, and introducing `eprop_isi_trace_cutoff_steps`, representing the cutoff in steps.

Since multiple calls to `Simulate` are possible, the maximum value of `eprop_isi_trace_cutoff` cannot be predetermined, so it is set to `std::numeric_limits<double>::max()`.

In the integration loop of `compute_gradient`, both `t` and `t_compute_until` are required when calling:
```cpp
weight = optimizer->optimized_weight(*ecp.optimizer_cp_, t, grad, weight);
```
and
```cpp
weight = optimizer->optimized_weight(*ecp.optimizer_cp_, t_compute_until, grad, weight);
```
thus the overflow is prevented via

```cpp
  const long t_compute_until = V_.eprop_isi_trace_cutoff_steps_ == std::numeric_limits< long >::max()
    ? t_spike
    : std::min( t_spike_previous + V_.eprop_isi_trace_cutoff_steps_, t_spike );
```