### PR TITLE
Refactor cleaning of eprop update history

### DIFF
--- a/models/eprop_iaf_adapt_bsshslm_2020.cpp
+++ b/models/eprop_iaf_adapt_bsshslm_2020.cpp
@@ -318,7 +318,6 @@ eprop_iaf_adapt_bsshslm_2020::update( Time const& origin, const long from, const
     if ( interval_step == 0 )
     {
       erase_used_firing_rate_reg_history();
-      erase_used_update_history();
       erase_used_eprop_history();
 
       if ( with_reset )

--- a/models/eprop_iaf_bsshslm_2020.cpp
+++ b/models/eprop_iaf_bsshslm_2020.cpp
@@ -283,7 +283,6 @@ eprop_iaf_bsshslm_2020::update( Time const& origin, const long from, const long 
     if ( interval_step == 0 )
     {
       erase_used_firing_rate_reg_history();
-      erase_used_update_history();
       erase_used_eprop_history();
 
       if ( with_reset )

--- a/models/eprop_readout_bsshslm_2020.cpp
+++ b/models/eprop_readout_bsshslm_2020.cpp
@@ -261,7 +261,6 @@ eprop_readout_bsshslm_2020::update( Time const& origin, const long from, const l
 
     if ( interval_step == 0 )
     {
-      erase_used_update_history();
       erase_used_eprop_history();
 
       if ( with_reset )

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -145,11 +145,6 @@ public:
   //! Get an iterator pointing to the eprop history entry of the given time step.
   typename std::vector< HistEntryT >::iterator get_eprop_history( const long time_step );
 
-  /**
-   * Erase update history parts for which the access counter has decreased to zero since no synapse needs them any
-   * longer.
-   */
-  void erase_used_update_history();
 
   /**
    * Erase e-prop history entries corresponding to update intervals during which no spikes were transmitted to target

--- a/nestkernel/eprop_archiving_node_impl.h
+++ b/nestkernel/eprop_archiving_node_impl.h
@@ -103,11 +103,10 @@ EpropArchivingNode< HistEntryT >::write_update_to_history( const long t_previous
   {
     // If an entry exists for the previous update time, decrement its access counter
     --it_hist_prev->access_counter_;
-  }
-
-  if ( not is_bsshslm_2020_model )
-  {
-    erase_used_update_history();
+    if ( it_hist_prev->access_counter_ == 0 )
+    {
+      update_history_.erase( it_hist_prev );
+    }
   }
 }
 
@@ -184,25 +183,6 @@ EpropArchivingNode< HistEntryT >::erase_used_eprop_history( const long eprop_isi
   const auto it_eprop_hist_from_2 = get_eprop_history( std::numeric_limits< long >::min() );
   const auto it_eprop_hist_to_2 = get_eprop_history( update_history_.begin()->t_ - 1 );
   eprop_history_.erase( it_eprop_hist_from_2, it_eprop_hist_to_2 ); // erase found entries since no longer used
-}
-
-template < typename HistEntryT >
-void
-EpropArchivingNode< HistEntryT >::erase_used_update_history()
-{
-  auto it_hist = update_history_.begin();
-  while ( it_hist != update_history_.end() )
-  {
-    if ( it_hist->access_counter_ == 0 )
-    {
-      // erase() invalidates the iterator, but returns a new, valid iterator
-      it_hist = update_history_.erase( it_hist );
-    }
-    else
-    {
-      ++it_hist;
-    }
-  }
 }
 
 } // namespace nest


### PR DESCRIPTION
This PR refactors how update history is managed in eprop models, focusing specifically on cleaning up eprop update history. Previously, `erase_used_update_history()` was called at each update interval, regardless of whether the update history requires cleaning. This method has now been removed. Instead, individual elements of the update history are erased only if their access counter reaches zero, indicating they are no longer needed.
