### PR TITLE
Refactor recording of eprop history duration

### DIFF
--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf::get_eprop_history_duration );
   insert_( names::learning_signal, &eprop_iaf::get_learning_signal_ );
   insert_( names::surrogate_gradient, &eprop_iaf::get_surrogate_gradient_ );
   insert_( names::V_m, &eprop_iaf::get_v_m_ );

--- a/models/eprop_iaf.h
+++ b/models/eprop_iaf.h
@@ -561,15 +561,6 @@ private:
     return S_.learning_signal_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf_adapt >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf_adapt::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf_adapt::get_eprop_history_duration );
   insert_( names::adaptation, &eprop_iaf_adapt::get_adaptation_ );
   insert_( names::V_th_adapt, &eprop_iaf_adapt::get_v_th_adapt_ );
   insert_( names::learning_signal, &eprop_iaf_adapt::get_learning_signal_ );

--- a/models/eprop_iaf_adapt.h
+++ b/models/eprop_iaf_adapt.h
@@ -558,15 +558,6 @@ private:
     return S_.adapt_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_iaf_adapt_bsshslm_2020.cpp
+++ b/models/eprop_iaf_adapt_bsshslm_2020.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf_adapt_bsshslm_2020 >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf_adapt_bsshslm_2020::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf_adapt_bsshslm_2020::get_eprop_history_duration );
   insert_( names::adaptation, &eprop_iaf_adapt_bsshslm_2020::get_adaptation_ );
   insert_( names::V_th_adapt, &eprop_iaf_adapt_bsshslm_2020::get_v_th_adapt_ );
   insert_( names::learning_signal, &eprop_iaf_adapt_bsshslm_2020::get_learning_signal_ );

--- a/models/eprop_iaf_adapt_bsshslm_2020.h
+++ b/models/eprop_iaf_adapt_bsshslm_2020.h
@@ -513,15 +513,6 @@ private:
     return S_.adapt_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_iaf_bsshslm_2020.cpp
+++ b/models/eprop_iaf_bsshslm_2020.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf_bsshslm_2020 >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf_bsshslm_2020::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf_bsshslm_2020::get_eprop_history_duration );
   insert_( names::learning_signal, &eprop_iaf_bsshslm_2020::get_learning_signal_ );
   insert_( names::surrogate_gradient, &eprop_iaf_bsshslm_2020::get_surrogate_gradient_ );
   insert_( names::V_m, &eprop_iaf_bsshslm_2020::get_v_m_ );

--- a/models/eprop_iaf_bsshslm_2020.h
+++ b/models/eprop_iaf_bsshslm_2020.h
@@ -469,16 +469,6 @@ private:
     return S_.learning_signal_;
   }
 
-
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf_psc_delta >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf_psc_delta::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf_psc_delta::get_eprop_history_duration );
   insert_( names::V_m, &eprop_iaf_psc_delta::get_v_m_ );
   insert_( names::learning_signal, &eprop_iaf_psc_delta::get_learning_signal_ );
   insert_( names::surrogate_gradient, &eprop_iaf_psc_delta::get_surrogate_gradient_ );

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -576,15 +576,6 @@ private:
     return S_.learning_signal_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_iaf_psc_delta_adapt >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_iaf_psc_delta_adapt::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_iaf_psc_delta_adapt::get_eprop_history_duration );
   insert_( names::V_m, &eprop_iaf_psc_delta_adapt::get_v_m_ );
   insert_( names::adaptation, &eprop_iaf_psc_delta_adapt::get_adaptation_ );
   insert_( names::V_th_adapt, &eprop_iaf_psc_delta_adapt::get_v_th_adapt_ );

--- a/models/eprop_iaf_psc_delta_adapt.h
+++ b/models/eprop_iaf_psc_delta_adapt.h
@@ -625,15 +625,6 @@ private:
     return S_.adapt_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_readout >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_readout::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_readout::get_eprop_history_duration );
   insert_( names::error_signal, &eprop_readout::get_error_signal_ );
   insert_( names::readout_signal, &eprop_readout::get_readout_signal_ );
   insert_( names::target_signal, &eprop_readout::get_target_signal_ );

--- a/models/eprop_readout.h
+++ b/models/eprop_readout.h
@@ -463,15 +463,6 @@ private:
     return S_.error_signal_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/models/eprop_readout_bsshslm_2020.cpp
+++ b/models/eprop_readout_bsshslm_2020.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< eprop_readout_bsshslm_2020 >::create()
 {
-  insert_( names::eprop_history_length_ms, &eprop_readout_bsshslm_2020::get_eprop_history_length_ms_ );
+  insert_( names::eprop_history_duration, &eprop_readout_bsshslm_2020::get_eprop_history_duration );
   insert_( names::error_signal, &eprop_readout_bsshslm_2020::get_error_signal_ );
   insert_( names::readout_signal, &eprop_readout_bsshslm_2020::get_readout_signal_ );
   insert_( names::readout_signal_unnorm, &eprop_readout_bsshslm_2020::get_readout_signal_unnorm_ );

--- a/models/eprop_readout_bsshslm_2020.h
+++ b/models/eprop_readout_bsshslm_2020.h
@@ -471,15 +471,6 @@ private:
     return S_.error_signal_;
   }
 
-  //! Get the size of the eprop history in milliseconds.
-  double
-  get_eprop_history_length_ms_() const
-  {
-    double step_ms = Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() );
-
-    return step_ms * get_eprop_history_length_ms();
-  }
-
   // the order in which the structure instances are defined is important for speed
 
   //! Structure of parameters.

--- a/nestkernel/eprop_archiving_node.h
+++ b/nestkernel/eprop_archiving_node.h
@@ -113,7 +113,7 @@ public:
    * Retrieves the size of the eprop history buffer.
    */
 
-  size_t get_eprop_history_length_ms() const;
+  double get_eprop_history_duration() const;
 
 protected:
   //! Number of incoming eprop synapses

--- a/nestkernel/eprop_archiving_node_impl.h
+++ b/nestkernel/eprop_archiving_node_impl.h
@@ -183,10 +183,10 @@ EpropArchivingNode< HistEntryT >::erase_used_eprop_history( const long eprop_isi
 }
 
 template < typename HistEntryT >
-inline size_t
-EpropArchivingNode< HistEntryT >::get_eprop_history_length_ms() const
+inline double
+EpropArchivingNode< HistEntryT >::get_eprop_history_duration() const
 {
-  return eprop_history_.size();
+  return Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() ) * eprop_history_.size();
 }
 
 } // namespace nest

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -176,7 +176,7 @@ const Name elements( "elements" );
 const Name elementsize( "elementsize" );
 const Name ellipsoidal( "ellipsoidal" );
 const Name elliptical( "elliptical" );
-const Name eprop_history_length_ms( "eprop_history_length_ms" );
+const Name eprop_history_duration( "eprop_history_duration" );
 const Name eprop_isi_trace_cutoff( "eprop_isi_trace_cutoff" );
 const Name eprop_learning_window( "eprop_learning_window" );
 const Name eprop_reset_neurons_on_update( "eprop_reset_neurons_on_update" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -203,7 +203,7 @@ extern const Name elements;
 extern const Name elementsize;
 extern const Name ellipsoidal;
 extern const Name elliptical;
-extern const Name eprop_history_length_ms;
+extern const Name eprop_history_duration;
 extern const Name eprop_isi_trace_cutoff;
 extern const Name eprop_learning_window;
 extern const Name eprop_reset_neurons_on_update;

--- a/testsuite/pytests/test_eprop_plasticity.py
+++ b/testsuite/pytests/test_eprop_plasticity.py
@@ -558,45 +558,23 @@ def test_eprop_surrogate_gradients(surrogate_gradient_type, surrogate_gradient_r
 
 
 @pytest.mark.parametrize(
-    "neuron_model,eprop_isi_trace_cutoff,eprop_history_length_ms_reference",
+    "neuron_model,eprop_isi_trace_cutoff,eprop_history_duration_reference",
     [
         (
             "eprop_iaf",
             5.0,
-            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
-             13.0, 14.0, 15.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 16.0, 17.0, 18.0, 19.0, 20.0,
-             21.0, 22.0, 23.0, 24.0, 25.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 17.0, 18.0, 19.0,
-             20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0,
-             23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0,
-             41.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0,
-             29.0],
+            np.hstack(
+                [
+                    np.arange(x, y)
+                    for x, y in [[1, 12], [6, 16], [11, 21], [16, 26], [21, 31], [17, 27], [12, 42], [12, 30]]
+                ]
+            ),
         ),
-        (
-            "eprop_iaf",
-            100000.0,
-            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
-             19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0,
-             37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 33.0, 34.0, 35.0,
-             36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0,
-             34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0,
-             52.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0, 59.0,
-             60.0],
-        ),
-        (
-            "eprop_readout",
-            100000.0,
-            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0,
-             19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0,
-             37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 33.0, 34.0, 35.0,
-             36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0,
-             34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0, 42.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0,
-             52.0, 43.0, 44.0, 45.0, 46.0, 47.0, 48.0, 49.0, 50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0, 59.0,
-             60.0],
-        ),                 
+        ("eprop_iaf", 100000.0, np.hstack([np.arange(x, y) for x, y in [[1, 52], [33, 43], [23, 53], [43, 61]]])),
+        ("eprop_readout", 100000.0, np.hstack([np.arange(x, y) for x, y in [[1, 52], [33, 43], [23, 53], [43, 61]]])),
     ],
 )
-def test_eprop_history_cleaning(neuron_model, eprop_isi_trace_cutoff, eprop_history_length_ms_reference):
-
+def test_eprop_history_cleaning(neuron_model, eprop_isi_trace_cutoff, eprop_history_duration_reference):
     # Define timing of task
 
     duration = {"step": 1.0}
@@ -626,7 +604,7 @@ def test_eprop_history_cleaning(neuron_model, eprop_isi_trace_cutoff, eprop_hist
 
     params_mm_rec = {
         "interval": duration["step"],
-        "record_from": ["eprop_history_length_ms"],
+        "record_from": ["eprop_history_duration"],
     }
 
     mm_rec = nest.Create("multimeter", params_mm_rec)
@@ -672,9 +650,9 @@ def test_eprop_history_cleaning(neuron_model, eprop_isi_trace_cutoff, eprop_hist
     # Evaluate eprop history size
 
     events_mm_rec = mm_rec.get("events")
-    
-    eprop_history_length_ms = events_mm_rec["eprop_history_length_ms"]
-    senders = events_mm_rec["senders"]
-    eprop_history_length_ms = np.array([eprop_history_length_ms[senders == i] for i in set(senders)])[0]
 
-    assert np.allclose(eprop_history_length_ms, eprop_history_length_ms_reference, rtol=1e-8)
+    eprop_history_duration = events_mm_rec["eprop_history_duration"]
+    senders = events_mm_rec["senders"]
+    eprop_history_duration = np.array([eprop_history_duration[senders == i] for i in set(senders)])[0]
+
+    assert np.allclose(eprop_history_duration, eprop_history_duration_reference, rtol=1e-8)


### PR DESCRIPTION
This PR refactors the retrieval of the eprop history duration by:

- Removing the `get_eprop_history_length_ms_()` functions from the neuron models.
- Renaming `eprop_history_length_ms` to `eprop_history_duration` to align with the naming convention for recording variables, which avoids including units in names.
- Introducing a centralized function, `get_eprop_history_duration()`, in the archiving node.
- Constructing the long, explicit lists in the pytest parameters from smaller subsequences for improved clarity and maintainability.